### PR TITLE
Implementing russian translation to UI.

### DIFF
--- a/Bot/MultilingualResources/Bot.ru.xlf
+++ b/Bot/MultilingualResources/Bot.ru.xlf
@@ -8,83 +8,83 @@
       <group id="BOT/PROPERTIES/RESOURCES.RESX" datatype="resx">
         <trans-unit id="BalloonNoNewSuspectsFound" translate="yes" xml:space="preserve">
           <source>No new suspects banned found.</source>
-          <target state="new">No new suspects banned found.</target>
+          <target state="needs-review">Нет новых банов среди подозреваемых.</target>
         </trans-unit>
         <trans-unit id="CheckEvery" translate="yes" xml:space="preserve">
           <source>Check every</source>
-          <target state="new">Check every</target>
+          <target state="needs-review">Проверять каждые</target>
         </trans-unit>
         <trans-unit id="CheckNow" translate="yes" xml:space="preserve">
           <source>Check now</source>
-          <target state="new">Check now</target>
+          <target state="needs-review">Проверить сейчас</target>
         </trans-unit>
         <trans-unit id="Error" translate="yes" xml:space="preserve">
           <source>Error</source>
-          <target state="new">Error</target>
+          <target state="needs-review">Ошибка</target>
         </trans-unit>
         <trans-unit id="IsNotRunning" translate="yes" xml:space="preserve">
           <source>is not running</source>
-          <target state="new">is not running</target>
+          <target state="needs-review">не запущен</target>
         </trans-unit>
         <trans-unit id="IsRunning" translate="yes" xml:space="preserve">
           <source>is running</source>
-          <target state="new">is running</target>
+          <target state="needs-review">запущен</target>
         </trans-unit>
         <trans-unit id="Language" translate="yes" xml:space="preserve">
           <source>Language</source>
-          <target state="new">Language</target>
+          <target state="needs-review">Язык</target>
         </trans-unit>
         <trans-unit id="LaunchAtStartup" translate="yes" xml:space="preserve">
           <source>Launch at startup</source>
-          <target state="new">Launch at startup</target>
+          <target state="needs-review">Запускать при входе в CSGO-DM</target>
         </trans-unit>
         <trans-unit id="Quit" translate="yes" xml:space="preserve">
           <source>Quit</source>
-          <target state="new">Quit</target>
+          <target state="needs-review">Выход</target>
         </trans-unit>
         <trans-unit id="ShowCsgoDm" translate="yes" xml:space="preserve">
           <source>Show CSGO-DM</source>
-          <target state="new">Show CSGO-DM</target>
+          <target state="needs-review">Показать CSGO-DM</target>
         </trans-unit>
         <trans-unit id="Start" translate="yes" xml:space="preserve">
           <source>Start</source>
-          <target state="new">Start</target>
+          <target state="needs-review">Запустить</target>
         </trans-unit>
         <trans-unit id="Stop" translate="yes" xml:space="preserve">
           <source>Stop</source>
-          <target state="new">Stop</target>
+          <target state="needs-review">Остановить</target>
         </trans-unit>
         <trans-unit id="SuspectsList" translate="yes" xml:space="preserve">
           <source>Suspects list</source>
-          <target state="new">Suspects list</target>
+          <target state="needs-review">Лист подозреваемых</target>
         </trans-unit>
         <trans-unit id="UnableToStartBot" translate="yes" xml:space="preserve">
           <source>Unable to start the BOT.</source>
-          <target state="new">Unable to start the BOT.</target>
+          <target state="needs-review">Невозможно запустить бота.</target>
         </trans-unit>
         <trans-unit id="Xhour" translate="yes" xml:space="preserve">
           <source>{0} hour</source>
-          <target state="new">{0} hour</target>
+          <target state="needs-review">{0} час</target>
         </trans-unit>
         <trans-unit id="Xhours" translate="yes" xml:space="preserve">
           <source>{0} hours</source>
-          <target state="new">{0} hours</target>
+          <target state="needs-review">{0} часов</target>
         </trans-unit>
         <trans-unit id="Xminutes" translate="yes" xml:space="preserve">
           <source>{0} minutes</source>
-          <target state="new">{0} minutes</target>
+          <target state="needs-review">{0} минут</target>
         </trans-unit>
         <trans-unit id="XsuspectsHaveBeenBanned" translate="yes" xml:space="preserve">
           <source>{0} suspect(s) has been banned.</source>
-          <target state="new">{0} suspect(s) has been banned.</target>
+          <target state="needs-review">{0} подозреваемых забанено.</target>
         </trans-unit>
         <trans-unit id="DownloadDemos" translate="yes" xml:space="preserve">
           <source>Click here to download your last matchmaking demos.</source>
-          <target state="new">Click here to download your last matchmaking demos.</target>
+          <target state="needs-review">Нажмите здесь, чтобы скачать ваши последние ММ демки.</target>
         </trans-unit>
         <trans-unit id="SendDownloadNotification" translate="yes" xml:space="preserve">
           <source>Send download demos notifications</source>
-          <target state="new">Send download demos notifications</target>
+          <target state="needs-review">Напоминать скачивать демки</target>
         </trans-unit>
       </group>
     </body>

--- a/Core/AppSettings.cs
+++ b/Core/AppSettings.cs
@@ -127,7 +127,7 @@ namespace Core
             {
                 Key = "ru-RU",
                 Name = "Russian",
-                IsEnabled = false,
+                IsEnabled = true,
             },
             new Language
             {

--- a/Core/MultilingualResources/Core.ru.xlf
+++ b/Core/MultilingualResources/Core.ru.xlf
@@ -120,79 +120,79 @@
         </trans-unit>
         <trans-unit id="Rank0" translate="yes" xml:space="preserve">
           <source>None</source>
-          <target state="new">None</target>
+          <target state="needs-review">Без ранга</target>
         </trans-unit>
         <trans-unit id="Rank1" translate="yes" xml:space="preserve">
           <source>Silver I</source>
-          <target state="new">Silver I</target>
+          <target state="needs-review">Серебро - I</target>
         </trans-unit>
         <trans-unit id="Rank10" translate="yes" xml:space="preserve">
           <source>Gold Nova Master</source>
-          <target state="new">Gold Nova Master</target>
+          <target state="needs-review">Золотая Звезда - Магистр</target>
         </trans-unit>
         <trans-unit id="Rank11" translate="yes" xml:space="preserve">
           <source>Master Guardian I</source>
-          <target state="new">Master Guardian I</target>
+          <target state="needs-review">Магистр-хранитель - I</target>
         </trans-unit>
         <trans-unit id="Rank12" translate="yes" xml:space="preserve">
           <source>Master Guardian II</source>
-          <target state="new">Master Guardian II</target>
+          <target state="needs-review">Магистр-хранитель - II</target>
         </trans-unit>
         <trans-unit id="Rank13" translate="yes" xml:space="preserve">
           <source>Master Guardian Elite</source>
-          <target state="new">Master Guardian Elite</target>
+          <target state="needs-review">Магистр-хранитель - Элита</target>
         </trans-unit>
         <trans-unit id="Rank14" translate="yes" xml:space="preserve">
           <source>Distinguished Master Guardian</source>
-          <target state="new">Distinguished Master Guardian</target>
+          <target state="needs-review">Заслуженный Магистр-хранитель</target>
         </trans-unit>
         <trans-unit id="Rank15" translate="yes" xml:space="preserve">
           <source>Legendary Eagle</source>
-          <target state="new">Legendary Eagle</target>
+          <target state="needs-review">Легендарный Беркут</target>
         </trans-unit>
         <trans-unit id="Rank16" translate="yes" xml:space="preserve">
           <source>Legendary Eagle Master</source>
-          <target state="new">Legendary Eagle Master</target>
+          <target state="needs-review">Легендарный Беркут-магистр</target>
         </trans-unit>
         <trans-unit id="Rank17" translate="yes" xml:space="preserve">
           <source>Supreme Master First Class</source>
-          <target state="new">Supreme Master First Class</target>
+          <target state="needs-review">Великий Магистр Высшего Ранга</target>
         </trans-unit>
         <trans-unit id="Rank18" translate="yes" xml:space="preserve">
           <source>Global Elite</source>
-          <target state="new">Global Elite</target>
+          <target state="needs-review">Всемирная Элита</target>
         </trans-unit>
         <trans-unit id="Rank2" translate="yes" xml:space="preserve">
           <source>Silver II</source>
-          <target state="new">Silver II</target>
+          <target state="needs-review">Серебро - II</target>
         </trans-unit>
         <trans-unit id="Rank3" translate="yes" xml:space="preserve">
           <source>Silver III</source>
-          <target state="new">Silver III</target>
+          <target state="needs-review">Серебро - III</target>
         </trans-unit>
         <trans-unit id="Rank4" translate="yes" xml:space="preserve">
           <source>Silver IV</source>
-          <target state="new">Silver IV</target>
+          <target state="needs-review">Серебро - IV</target>
         </trans-unit>
         <trans-unit id="Rank5" translate="yes" xml:space="preserve">
           <source>Silver Elite</source>
-          <target state="new">Silver Elite</target>
+          <target state="needs-review">Серебро - Элита</target>
         </trans-unit>
         <trans-unit id="Rank6" translate="yes" xml:space="preserve">
           <source>Silver Elite Master</source>
-          <target state="new">Silver Elite Master</target>
+          <target state="needs-review">Серебро - Великий Магистр</target>
         </trans-unit>
         <trans-unit id="Rank7" translate="yes" xml:space="preserve">
           <source>Gold Nova I</source>
-          <target state="new">Gold Nova I</target>
+          <target state="needs-review">Золотая Звезда - I</target>
         </trans-unit>
         <trans-unit id="Rank8" translate="yes" xml:space="preserve">
           <source>Gold Nova II</source>
-          <target state="new">Gold Nova II</target>
+          <target state="needs-review">Золотая Звезда - II</target>
         </trans-unit>
         <trans-unit id="Rank9" translate="yes" xml:space="preserve">
           <source>Gold Nova III</source>
-          <target state="new">Gold Nova III</target>
+          <target state="needs-review">Золотая Звезда - III</target>
         </trans-unit>
         <trans-unit id="valve" translate="no" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
           <source>..\Resources\Images\Logos\valve.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</source>

--- a/Manager/App.xaml.cs
+++ b/Manager/App.xaml.cs
@@ -47,6 +47,7 @@ namespace Manager
             "Paco González López / monxas (Spanish)",
             "aLieN (Hungarian)",
             "Mad-Kingu (Turkish)",
+            "Aleksandr \"3vaLpwner\" Kolesnikov (Russian)",
         };
 
         public App()

--- a/Manager/MultilingualResources/Manager.ru.xlf
+++ b/Manager/MultilingualResources/Manager.ru.xlf
@@ -1676,7 +1676,7 @@
         </trans-unit>
         <trans-unit id="HeGrenades" translate="yes" xml:space="preserve">
           <source>HE Grenades</source>
-          <target state="needs-review">Боевые гранаты</target>
+          <target state="needs-review">Осколочные гранаты</target>
         </trans-unit>
         <trans-unit id="Incendiaries" translate="yes" xml:space="preserve">
           <source>Incendiaries</source>
@@ -2250,7 +2250,7 @@ You can find more information on {0}.
 - POV демки не поддерживаются.
 - Демки, взятые с пользовательского сервера, официально не поддерживаются и поэтому могут работать некорректно, вы можете попробовать изменить источник демки и повторно проанализировать её.
 
-Пожалуйста создавайте заявку на GitHub с упомянутыми демками, только если они получены из поддерживаемого источника. 
+Пожалуйста, создавайте заявку на GitHub с упомянутыми демками, только если они получены из поддерживаемого источника. 
 Дополнительную информацию вы можете найти на {0}.
 
 {1}</target>
@@ -2507,7 +2507,7 @@ Unable to start the game.</source>
         </trans-unit>
         <trans-unit id="DialogSelectCsgoPath" translate="yes" xml:space="preserve">
           <source>Please select the csgo.exe file location to enable it.</source>
-          <target state="needs-review">Пожалуйста выберите расположение файла csgo.exe, чтобы включить эту опцию'.</target>
+          <target state="needs-review">Выберите расположение файла csgo.exe, чтобы включить эту опцию'.</target>
         </trans-unit>
         <trans-unit id="DialogVdmFilesDeleted" translate="yes" xml:space="preserve">
           <source>VDM files deleted.</source>
@@ -2566,7 +2566,7 @@ You can find more information on {1}.</source>
 - POV демки не поддерживаются.
 - Демки, взятые с пользовательского сервера, официально не поддерживаются и поэтому могут работать некорректно, вы можете попробовать изменить источник демки и повторно проанализировать её.
 
-Пожалуйста создавайте заявку на GitHub с упомянутой демкой, только если она получена из поддерживаемого источника. 
+Пожалуйста, создавайте заявку на GitHub с упомянутой демкой, только если она получена из поддерживаемого источника. 
 Дополнительную информацию вы можете найти на {1}.</target>
         </trans-unit>
         <trans-unit id="DialogMapNotSupported" translate="yes" xml:space="preserve">
@@ -2745,7 +2745,7 @@ You can find more information on {1}.</source>
           <source>It seems that CSGO is not installed on your main hard drive.
 The defaults "csgo" and "replays" can not be found. Please add folders from the settings.</source>
           <target state="needs-review">Похоже, CSGO не установлена на вашем основном жестком диске.
-Не удается найти папки «csgo» и «replays». Пожалуйста добавьте папки через настройки.</target>
+Не удается найти папки «csgo» и «replays». Добавьте папки через настройки.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileDeletingPlayer" translate="yes" xml:space="preserve">
           <source>Error while deleting player.</source>
@@ -3262,7 +3262,7 @@ You have to remove it from your account list to be able to add him in your white
           <source>An unexpected error occured. Please send the 'errors.log' file accessible from settings.
 Message Error :
 {0}</source>
-          <target state="needs-review">Возникла непредвиденная ошибка. Пожалуйста отправьте доступный в настройках файл 'errors.log'.
+          <target state="needs-review">Возникла непредвиденная ошибка. Отправьте доступный в настройках файл 'errors.log'.
 Сообщение об Ошибке :
 {0}</target>
         </trans-unit>
@@ -3374,7 +3374,7 @@ Message Error :
         </trans-unit>
         <trans-unit id="DialogConfigurationCorrupted" translate="yes" xml:space="preserve">
           <source>Your configuration file is corrupted. Please restart the application to reset your configuration.</source>
-          <target state="needs-review">Ваша конфигурация повреждена. Пожалуйста перезагрузите приложение, чтобы сбросить вашу конфигурацию.</target>
+          <target state="needs-review">Ваша конфигурация повреждена. Перезагрузите приложение, чтобы сбросить вашу конфигурацию.</target>
         </trans-unit>
         <trans-unit id="EnableMovieMakingConfigParentFolder" translate="yes" xml:space="preserve">
           <source>Enable movie making config parent folder</source>
@@ -3466,7 +3466,7 @@ Do you want to install it? (It's recommended to avoid possible crash due to CSGO
 Please enter the share code (example: CSGO-orkmt-Z8udN-apVEh-GQtx3-sU7CR).</source>
           <target state="needs-review">Вы собираетесь скачать демку по общему коду.
 
-Пожалуйста введите общий код (пример: CSGO-orkmt-Z8udN-apVEh-GQtx3-sU7CR).</target>
+Введите общий код (пример: CSGO-orkmt-Z8udN-apVEh-GQtx3-sU7CR).</target>
         </trans-unit>
         <trans-unit id="DialogTitleDownloadDemoFromShareCode" translate="yes" xml:space="preserve">
           <source>Download demo from share code</source>
@@ -3606,7 +3606,7 @@ You may have missing data for this demos.</source>
         </trans-unit>
         <trans-unit id="HE" translate="yes" xml:space="preserve">
           <source>HE</source>
-          <target state="needs-review">БГ</target>
+          <target state="needs-review">ОГ</target>
         </trans-unit>
         <trans-unit id="Incendiary" translate="yes" xml:space="preserve">
           <source>Incendiary</source>
@@ -3748,25 +3748,25 @@ Do you want to continue?</source>
         </trans-unit>
         <trans-unit id="DialogInstallFFmpegFirst" translate="yes" xml:space="preserve">
           <source>Please install FFmpeg first from FFmpeg section.</source>
-          <target state="needs-review">Пожалуйста сначала установите FFmpeg из раздела FFmpeg.</target>
+          <target state="needs-review">Сначала установите FFmpeg из раздела FFmpeg.</target>
         </trans-unit>
         <trans-unit id="DialogInstallHLAEFirst" translate="yes" xml:space="preserve">
           <source>Please install HLAE first from HLAE section.</source>
-          <target state="needs-review">Пожалуйста сначала установите HLAE из раздела HLAE.</target>
+          <target state="needs-review">Сначала установите HLAE из раздела HLAE.</target>
         </trans-unit>
         <trans-unit id="DialogInstallVirtuaDubFirst" translate="yes" xml:space="preserve">
           <source>Please install VirtualDub first from VirtualDub section.</source>
-          <target state="needs-review">Пожалуйста сначала установите VirtualDub из раздела VirtualDub.</target>
+          <target state="needs-review">Сначала установите VirtualDub из раздела VirtualDub.</target>
         </trans-unit>
         <trans-unit id="DialogPleaseUpdateHLAE" translate="yes" xml:space="preserve">
           <source>A new HLAE version is available.
 Please update it by clicking on the "Update" button.</source>
           <target state="needs-review">Доступна новая версия HLAE.
-Пожалуйста обновите его, нажав кнопку "Обновить".</target>
+Обновите его, нажав кнопку "Обновить".</target>
         </trans-unit>
         <trans-unit id="DialogSelectCsgoExeLocation" translate="yes" xml:space="preserve">
           <source>Please select csgo.exe path from HLAE section.</source>
-          <target state="needs-review">Пожалуйста укажите путь к файлу csgo.exe в разделе HLAE.</target>
+          <target state="needs-review">Укажите путь к файлу csgo.exe в разделе HLAE.</target>
         </trans-unit>
         <trans-unit id="DialogSelectRawFilesDestination" translate="yes" xml:space="preserve">
           <source>Please select a raw files folder destination.</source>
@@ -3800,7 +3800,7 @@ Please update it by clicking on the "Update" button.</source>
         </trans-unit>
         <trans-unit id="FFmpegEncodingInProgress" translate="yes" xml:space="preserve">
           <source>FFmpeg encoding in progress, please wait...</source>
-          <target state="needs-review">FFmpeg кодирование в процессе, подождите...</target>
+          <target state="needs-review">Производится кодирование при помощи FFmpeg, подождите...</target>
         </trans-unit>
         <trans-unit id="FollowingCFGWillBeExecuted" translate="yes" xml:space="preserve">
           <source>The following CFG will be automatically executed:</source>
@@ -3828,7 +3828,7 @@ Please update it by clicking on the "Update" button.</source>
         </trans-unit>
         <trans-unit id="InstallingVirtualDub" translate="yes" xml:space="preserve">
           <source>Installing VirtualDub...</source>
-          <target state="needs-review">Устанавливается VirtualDub...</target>
+          <target state="needs-review">VirtualDub устанавливается......</target>
         </trans-unit>
         <trans-unit id="Killed" translate="yes" xml:space="preserve">
           <source>killed</source>
@@ -3888,7 +3888,7 @@ Please update it by clicking on the "Update" button.</source>
         </trans-unit>
         <trans-unit id="LabelVideoFramerate" translate="yes" xml:space="preserve">
           <source>Video framerate:</source>
-          <target state="needs-review">Фреймрейт видео:</target>
+          <target state="needs-review">Частота кадров видео:</target>
         </trans-unit>
         <trans-unit id="LabelVideoQuality" translate="yes" xml:space="preserve">
           <source>Video quality:</source>
@@ -3944,7 +3944,7 @@ Please update it by clicking on the "Update" button.</source>
         </trans-unit>
         <trans-unit id="StartingCSGO" translate="yes" xml:space="preserve">
           <source>Starting CSGO, please wait...</source>
-          <target state="needs-review">Запускается CSGO, подождите...</target>
+          <target state="needs-review">CSGO запускается, подождите...</target>
         </trans-unit>
         <trans-unit id="TimeLineNotAvailableWarning" translate="yes" xml:space="preserve">
           <source>Timeline is not available with POV or corrupted demos. You have to enter ticks manually. Adding a comment to the demo may be useful in this case.</source>
@@ -4016,11 +4016,11 @@ Please update it by clicking on the "Update" button.</source>
         </trans-unit>
         <trans-unit id="ValidNumberRequired" translate="yes" xml:space="preserve">
           <source>A valid number is required.</source>
-          <target state="needs-review">Требуется корректное число.</target>
+          <target state="needs-review">Требуется числовое значение.</target>
         </trans-unit>
         <trans-unit id="VirtualDubEncodingInProgress" translate="yes" xml:space="preserve">
           <source>VirtualDub encoding in progress, please wait...</source>
-          <target state="needs-review">VirtualDub кодирование в процессе, подождите...</target>
+          <target state="needs-review">Производится кодирование при помощи VirtualDub, подождите...</target>
         </trans-unit>
         <trans-unit id="With" translate="yes" xml:space="preserve">
           <source>with</source>
@@ -4069,7 +4069,7 @@ Please update it by clicking on the "Update" button.</source>
           <target state="needs-review">Фокус на убийце</target>
         </trans-unit>
         <trans-unit id="Movie" translate="yes" xml:space="preserve">
-          <source>Movie</source>
+          <source>Movie</source>о
           <target state="needs-review">Видеофайл</target>
         </trans-unit>
         <trans-unit id="ToolTipMovie" translate="yes" xml:space="preserve">
@@ -4078,31 +4078,31 @@ Please update it by clicking on the "Update" button.</source>
         </trans-unit>
         <trans-unit id="Adecoy" translate="yes" xml:space="preserve">
           <source>a decoy</source>
-          <target state="needs-review">отвлекающую гранату</target>
+          <target state="needs-review">отвлекающую</target>
         </trans-unit>
         <trans-unit id="AFlashbang" translate="yes" xml:space="preserve">
           <source>a flashbang</source>
-          <target state="needs-review">световую гранату</target>
+          <target state="needs-review">световую</target>
         </trans-unit>
         <trans-unit id="AMolotov" translate="yes" xml:space="preserve">
           <source>a molotov</source>
-          <target state="needs-review">коктейль Молотова</target>
+          <target state="needs-review">Молотов</target>
         </trans-unit>
         <trans-unit id="AnHE" translate="yes" xml:space="preserve">
           <source>an HE</source>
-          <target state="needs-review">БГ</target>
+          <target state="needs-review">осколочную</target>
         </trans-unit>
         <trans-unit id="AnIncendiary" translate="yes" xml:space="preserve">
           <source>an incendiary</source>
-          <target state="needs-review">зажигательную гранату</target>
+          <target state="needs-review">зажигательную</target>
         </trans-unit>
         <trans-unit id="Asmoke" translate="yes" xml:space="preserve">
           <source>a smoke</source>
-          <target state="needs-review">дымовую гранату</target>
+          <target state="needs-review">дымовую</target>
         </trans-unit>
         <trans-unit id="Thrown" translate="yes" xml:space="preserve">
           <source>thrown</source>
-          <target state="needs-review">брошена</target>
+          <target state="needs-review">бросил</target>
         </trans-unit>
         <trans-unit id="ToolTipShowCFG" translate="yes" xml:space="preserve">
           <source>Show CFG</source>
@@ -4118,7 +4118,7 @@ Please update it by clicking on the "Update" button.</source>
         </trans-unit>
         <trans-unit id="NotificationInstallingFFmpeg" translate="yes" xml:space="preserve">
           <source>Installing FFmpeg...</source>
-          <target state="needs-review">Устанавливается FFmpeg...</target>
+          <target state="needs-review">FFmpeg устанавливается...</target>
         </trans-unit>
         <trans-unit id="CreditsTools" translate="yes" xml:space="preserve">
           <source>CSGO Demo Manager uses internally the following tools:</source>
@@ -4174,11 +4174,11 @@ Please update it by clicking on the "Update" button.</source>
         </trans-unit>
         <trans-unit id="LabelDisplayTimeSeconds" translate="yes" xml:space="preserve">
           <source>Display time (seconds):</source>
-          <target state="needs-review">Оотображать время (секунды):</target>
+          <target state="needs-review">Отображать время (секунды):</target>
         </trans-unit>
         <trans-unit id="CheckForUpdatesOnAppStartup" translate="yes" xml:space="preserve">
           <source>Check for updates on app startup</source>
-          <target state="needs-review">Проверять на обновления при запуске</target>
+          <target state="needs-review">Проверять обновления при запуске</target>
         </trans-unit>
         <trans-unit id="MaxConcurrentAnalyzes" translate="yes" xml:space="preserve">
           <source>Max concurrent demo analyzes</source>
@@ -4226,7 +4226,7 @@ Please update it by clicking on the "Update" button.</source>
         </trans-unit>
         <trans-unit id="DialogInvalidExecutable" translate="yes" xml:space="preserve">
           <source>Invalid executable.</source>
-          <target state="needs-review">Неверный исполняемый файл.</target>
+          <target state="needs-review">Недопустимый исполняемый файл.</target>
         </trans-unit>
         <trans-unit id="DialogInvalidHlaeExecutablePath" translate="yes" xml:space="preserve">
           <source>The path contains non-basic latin characters which may lead to unexpected behaviors in-game. Please select a folder that contains only 7-bit ASCII characters.</source>
@@ -4234,24 +4234,24 @@ Please update it by clicking on the "Update" button.</source>
         </trans-unit>
         <trans-unit id="HlaeNotFound" translate="yes" xml:space="preserve">
           <source>HLAE not found. Please install it by enabling it from settings.</source>
-          <target state="needs-review">HLAE не найден. Установите его, включив его в настройках.</target>
+          <target state="needs-review">HLAE не найден. Установите его при помощи меню настроек.</target>
         </trans-unit>
         <trans-unit id="DialogErrorKillingCsgo" translate="yes" xml:space="preserve">
           <source>Failed to close CSGO, please do it manually and try again.
 Error: {0}.</source>
-          <target state="needs-review">Ошибка при закрытии CSGO, сделайте это вручную и попробуйте снова.
+          <target state="needs-review">Не удалось закрыть CSGO, сделайте это вручную и попробуйте снова.
 Ошибка: {0}.</target>
         </trans-unit>
         <trans-unit id="DialogErrorKillingHlae" translate="yes" xml:space="preserve">
           <source>Failed to close HLAE, please do it manually and try again.
 Error: {0}.</source>
-          <target state="needs-review">Ошибка при закрытии HLAE, сделайте это вручную и попробуйте снова.
+          <target state="needs-review">Не удалось закрыть HLAE, сделайте это вручную и попробуйте снова.
 Ошибка: {0}.</target>
         </trans-unit>
         <trans-unit id="DialogErrorStartingCsgo" translate="yes" xml:space="preserve">
           <source>Failed to start CSGO.
 Error: {0}.</source>
-          <target state="needs-review">Ошибка при запуске CSGO.
+          <target state="needs-review">Не удалось запустить CSGO.
 Ошибка: {0}.</target>
         </trans-unit>
         <trans-unit id="DialogInvalidDemo" translate="yes" xml:space="preserve">
@@ -4276,7 +4276,7 @@ Error: {0}.</source>
         </trans-unit>
         <trans-unit id="ExportPlayersVoice" translate="yes" xml:space="preserve">
           <source>Export players voice</source>
-          <target state="needs-review">Экспортировать голос игроков</target>
+          <target state="needs-review">Экспорт голосового чата</target>
         </trans-unit>
         <trans-unit id="CsgoNotFound" translate="yes" xml:space="preserve">
           <source>CSGO not found.</source>
@@ -4296,7 +4296,7 @@ Error: {0}.</source>
         </trans-unit>
         <trans-unit id="FailedToLoadCsgoAudioLibrary" translate="yes" xml:space="preserve">
           <source>Failed to load CSGO audio library.</source>
-          <target state="needs-review">Ошибка при запуске аудио библиотеки CSGO.</target>
+          <target state="needs-review">Не удалось загрузить аудио библиотеку CSGO.</target>
         </trans-unit>
         <trans-unit id="NoPlayersVoiceDataFound" translate="yes" xml:space="preserve">
           <source>{0}: No players voice data found.</source>
@@ -4312,11 +4312,11 @@ Error: {0}.</source>
         </trans-unit>
         <trans-unit id="WatchAsSuspect" translate="yes" xml:space="preserve">
           <source>Watch as a suspect</source>
-          <target state="needs-review">Смотреть как подозреваемого</target>
+          <target state="needs-review">Смотреть от лица подозреваемого</target>
         </trans-unit>
         <trans-unit id="DialogStartingCsgoAccessDenied" translate="yes" xml:space="preserve">
           <source>Access was denied when trying to start CSGO. Make sure to close any running anti cheat software and retry.</source>
-          <target state="needs-review">Доступ запрещен при попытке запустить CSGO. Убедитесь, что закрыли все запущенные античитерские программы и попробуйте снова.</target>
+          <target state="needs-review">Ошибка при попытке запуска CSGO: доступ запрещён. Закройте все античит-программы и попробуйте снова.</target>
         </trans-unit>
         <trans-unit id="DemoTypeGotv" translate="yes" xml:space="preserve">
           <source>GOTV</source>

--- a/Manager/MultilingualResources/Manager.ru.xlf
+++ b/Manager/MultilingualResources/Manager.ru.xlf
@@ -16,2224 +16,2224 @@
         </trans-unit>
         <trans-unit id="Analyze" translate="yes" xml:space="preserve">
           <source>Analyze</source>
-          <target state="new">Analyze</target>
+          <target state="needs-review">Анализ</target>
         </trans-unit>
         <trans-unit id="Back" translate="yes" xml:space="preserve">
           <source>Back</source>
-          <target state="new">Back</target>
+          <target state="needs-review">Назад</target>
         </trans-unit>
         <trans-unit id="Details" translate="yes" xml:space="preserve">
           <source>Details</source>
-          <target state="new">Details</target>
+          <target state="needs-review">Подробнее</target>
         </trans-unit>
         <trans-unit id="AccountStats" translate="yes" xml:space="preserve">
           <source>Account Stats</source>
-          <target state="new">Account Stats</target>
+          <target state="needs-review">Статистика Аккаунта</target>
         </trans-unit>
         <trans-unit id="AddToSuspects" translate="yes" xml:space="preserve">
           <source>Add to suspects</source>
-          <target state="new">Add to suspects</target>
+          <target state="needs-review">Добавить в подозреваемые</target>
         </trans-unit>
         <trans-unit id="Browse" translate="yes" xml:space="preserve">
           <source>Browse</source>
-          <target state="new">Browse</target>
+          <target state="needs-review">Расположение</target>
         </trans-unit>
         <trans-unit id="Delete" translate="yes" xml:space="preserve">
           <source>Delete</source>
-          <target state="new">Delete</target>
+          <target state="needs-review">Удалить</target>
         </trans-unit>
         <trans-unit id="DownloadMatchMakingDemos" translate="yes" xml:space="preserve">
           <source>Download MM Demos</source>
-          <target state="new">Download MM Demos</target>
+          <target state="needs-review">Скачать MM Демки</target>
         </trans-unit>
         <trans-unit id="ExportAsXls" translate="yes" xml:space="preserve">
           <source>Export as XLS</source>
-          <target state="new">Export as XLS</target>
+          <target state="needs-review">Экспорт в XLS</target>
         </trans-unit>
         <trans-unit id="GotoTick" translate="yes" xml:space="preserve">
           <source>Goto Tick</source>
-          <target state="new">Goto Tick</target>
+          <target state="needs-review">Задать Тик</target>
         </trans-unit>
         <trans-unit id="Information" translate="yes" xml:space="preserve">
           <source>Information</source>
-          <target state="new">Information</target>
+          <target state="needs-review">Информация</target>
         </trans-unit>
         <trans-unit id="Refresh" translate="yes" xml:space="preserve">
           <source>Refresh</source>
-          <target state="new">Refresh</target>
+          <target state="needs-review">Обновить</target>
         </trans-unit>
         <trans-unit id="ShowAll" translate="yes" xml:space="preserve">
           <source>Show All</source>
-          <target state="new">Show All</target>
+          <target state="needs-review">Показать все демки</target>
         </trans-unit>
         <trans-unit id="ShowOnlyAccountDemos" translate="yes" xml:space="preserve">
           <source>Show Only Account Demos</source>
-          <target state="new">Show Only Account Demos</target>
+          <target state="needs-review">Показывать только демки аккаунта</target>
         </trans-unit>
         <trans-unit id="Stats" translate="yes" xml:space="preserve">
           <source>Stats</source>
-          <target state="new">Stats</target>
+          <target state="needs-review">Статистика</target>
         </trans-unit>
         <trans-unit id="Suspects" translate="yes" xml:space="preserve">
           <source>Suspects</source>
-          <target state="new">Suspects</target>
+          <target state="needs-review">Подозреваемые</target>
         </trans-unit>
         <trans-unit id="Watch" translate="yes" xml:space="preserve">
           <source>Watch</source>
-          <target state="new">Watch</target>
+          <target state="needs-review">Смотреть</target>
         </trans-unit>
         <trans-unit id="WatchHighlights" translate="yes" xml:space="preserve">
           <source>Watch highlights</source>
-          <target state="new">Watch highlights</target>
+          <target state="needs-review">Смотреть хайлайты</target>
         </trans-unit>
         <trans-unit id="WatchLowlights" translate="yes" xml:space="preserve">
           <source>Watch lowlights</source>
-          <target state="new">Watch lowlights</target>
+          <target state="needs-review">Смотреть лоулайты</target>
         </trans-unit>
         <trans-unit id="About" translate="yes" xml:space="preserve">
           <source>About</source>
-          <target state="new">About</target>
+          <target state="needs-review">О программе</target>
         </trans-unit>
         <trans-unit id="FreeSoftware" translate="yes" xml:space="preserve">
           <source>CSGO Demo Manager is a free open source software and will always be.</source>
-          <target state="new">CSGO Demo Manager is a free open source software and will always be.</target>
+          <target state="needs-review">CSGO Demo Manager - свободное программное обеспечение с открытым исходным кодом и всегда будет таковым.</target>
         </trans-unit>
         <trans-unit id="SourceCodeAvailable" translate="yes" xml:space="preserve">
           <source>Source code is available on</source>
-          <target state="new">Source code is available on</target>
+          <target state="needs-review">Исходный код доступен на</target>
         </trans-unit>
         <trans-unit id="EncounteredBug" translate="yes" xml:space="preserve">
           <source>If you encountered a bug or have any suggestions, feel free to open an issue on</source>
-          <target state="new">If you encountered a bug or have any suggestions, feel free to open an issue on</target>
+          <target state="needs-review">Если вы обнаружили баг или у вас есть предложения, открывайте заявку на</target>
         </trans-unit>
         <trans-unit id="WantSayThank" translate="yes" xml:space="preserve">
           <source>If you want to say thank you, please feel free to make a</source>
-          <target state="new">If you want to say thank you, please feel free to make a</target>
+          <target state="needs-review">Если вы хотите сказать спасибо разработчикам, сделайте</target>
         </trans-unit>
         <trans-unit id="AlwaysDownload" translate="yes" xml:space="preserve">
           <source>Always download the application installer from the official website</source>
-          <target state="new">Always download the application installer from the official website</target>
+          <target state="needs-review">Всегда скачивайте установщик приложения с официального сайта</target>
         </trans-unit>
         <trans-unit id="Accounts" translate="yes" xml:space="preserve">
           <source>Accounts</source>
-          <target state="new">Accounts</target>
+          <target state="needs-review">Аккаунты</target>
         </trans-unit>
         <trans-unit id="AddAccount" translate="yes" xml:space="preserve">
           <source>Add account</source>
-          <target state="new">Add account</target>
+          <target state="needs-review">Добавить аккаунт</target>
         </trans-unit>
         <trans-unit id="AddFolder" translate="yes" xml:space="preserve">
           <source>Add folder</source>
-          <target state="new">Add folder</target>
+          <target state="needs-review">Добавить папку</target>
         </trans-unit>
         <trans-unit id="AdditionalsParametersLabel" translate="yes" xml:space="preserve">
           <source>Additionals parameters</source>
-          <target state="new">Additionals parameters</target>
+          <target state="needs-review">Дополнительные параметры</target>
         </trans-unit>
         <trans-unit id="HeaderAverageDamagesPerRound" translate="yes" xml:space="preserve">
           <source>ADR</source>
-          <target state="new">ADR</target>
+          <target state="needs-review">СУР</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Average Damage Per Round</note>
         </trans-unit>
         <trans-unit id="AdrFull" translate="yes" xml:space="preserve">
           <source>ADR (Average Damage Per Round)</source>
-          <target state="new">ADR (Average Damage Per Round)</target>
+          <target state="needs-review">СУР (Средний Урон за Раунд)</target>
         </trans-unit>
         <trans-unit id="AprFull" translate="yes" xml:space="preserve">
           <source>APR (Assist Per Round)</source>
-          <target state="new">APR (Assist Per Round)</target>
+          <target state="needs-review">ПЗР (Помощей за Раунд)</target>
         </trans-unit>
         <trans-unit id="Assists" translate="yes" xml:space="preserve">
           <source>Assists</source>
-          <target state="new">Assists</target>
+          <target state="needs-review">Помощей</target>
         </trans-unit>
         <trans-unit id="Ban" translate="yes" xml:space="preserve">
           <source>Ban</source>
-          <target state="new">Ban</target>
+          <target state="needs-review">Бан</target>
         </trans-unit>
         <trans-unit id="BanFull" translate="yes" xml:space="preserve">
           <source>Ban (VAC / OW)</source>
-          <target state="new">Ban (VAC / OW)</target>
+          <target state="needs-review">Бан (VAC / Патруль)</target>
         </trans-unit>
         <trans-unit id="HeaderBombDefused" translate="yes" xml:space="preserve">
           <source>BD</source>
-          <target state="new">BD</target>
+          <target state="needs-review">БР</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Bomb Defused</note>
         </trans-unit>
         <trans-unit id="HeaderBombExploded" translate="yes" xml:space="preserve">
           <source>BE</source>
-          <target state="new">BE</target>
+          <target state="needs-review">БВ</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Bomb Exploded</note>
         </trans-unit>
         <trans-unit id="BombDefused" translate="yes" xml:space="preserve">
           <source>Bomb defused</source>
-          <target state="new">Bomb defused</target>
+          <target state="needs-review">Бомб разминировано</target>
         </trans-unit>
         <trans-unit id="BombExploded" translate="yes" xml:space="preserve">
           <source>Bomb exploded</source>
-          <target state="new">Bomb exploded</target>
+          <target state="needs-review">Бомб взорвано</target>
         </trans-unit>
         <trans-unit id="BombPlanted" translate="yes" xml:space="preserve">
           <source>Bomb planted</source>
-          <target state="new">Bomb planted</target>
+          <target state="needs-review">Бомб установлено</target>
         </trans-unit>
         <trans-unit id="HeaderBombPlanted" translate="yes" xml:space="preserve">
           <source>BP</source>
-          <target state="new">BP</target>
+          <target state="needs-review">БУ</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Bomb Planted</note>
         </trans-unit>
         <trans-unit id="BrowseToErrorsFile" translate="yes" xml:space="preserve">
           <source>Browse to errors file</source>
-          <target state="new">Browse to errors file</target>
+          <target state="needs-review">Открыть файл с ошибками</target>
         </trans-unit>
         <trans-unit id="HeaderCrouchKills" translate="yes" xml:space="preserve">
           <source>CK</source>
-          <target state="new">CK</target>
+          <target state="needs-review">УС</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Crouch Kill</note>
         </trans-unit>
         <trans-unit id="ClearDemosData" translate="yes" xml:space="preserve">
           <source>Clear demos data</source>
-          <target state="new">Clear demos data</target>
+          <target state="needs-review">Очистить информацию о демках</target>
         </trans-unit>
         <trans-unit id="ClearVdmFiles" translate="yes" xml:space="preserve">
           <source>Clear VDM files</source>
-          <target state="new">Clear VDM files</target>
+          <target state="needs-review">Очистить VDM файлы</target>
         </trans-unit>
         <trans-unit id="ClientName" translate="yes" xml:space="preserve">
           <source>Client</source>
-          <target state="new">Client</target>
+          <target state="needs-review">Клиент</target>
         </trans-unit>
         <trans-unit id="CloseBotOnExit" translate="yes" xml:space="preserve">
           <source>Close BOT on exit</source>
-          <target state="new">Close BOT on exit</target>
+          <target state="needs-review">Закрыть бота при выходе из CSGO-DM</target>
         </trans-unit>
         <trans-unit id="Clutch" translate="yes" xml:space="preserve">
           <source>Clutch</source>
-          <target state="new">Clutch</target>
+          <target state="needs-review">Клатч</target>
         </trans-unit>
         <trans-unit id="Clutches" translate="yes" xml:space="preserve">
           <source>Clutches</source>
-          <target state="new">Clutches</target>
+          <target state="needs-review">Клатчи</target>
         </trans-unit>
         <trans-unit id="Columns" translate="yes" xml:space="preserve">
           <source>Columns</source>
-          <target state="new">Columns</target>
+          <target state="needs-review">Столбцы</target>
         </trans-unit>
         <trans-unit id="Comment" translate="yes" xml:space="preserve">
           <source>Comment</source>
-          <target state="new">Comment</target>
+          <target state="needs-review">Комментарий</target>
         </trans-unit>
         <trans-unit id="CommentLabel" translate="yes" xml:space="preserve">
           <source>Comment</source>
-          <target state="new">Comment</target>
+          <target state="needs-review">Комментарий</target>
         </trans-unit>
         <trans-unit id="CrouchKills" translate="yes" xml:space="preserve">
           <source>Crouch kills</source>
-          <target state="new">Crouch kills</target>
+          <target state="needs-review">Убийств сидя</target>
         </trans-unit>
         <trans-unit id="CsgoExePath" translate="yes" xml:space="preserve">
           <source>csgo.exe path</source>
-          <target state="new">csgo.exe path</target>
+          <target state="needs-review">Путь к файлу csgo.exe</target>
         </trans-unit>
         <trans-unit id="CurrentAccountWatch" translate="yes" xml:space="preserve">
           <source>Current account used for watch (highlights / lowlights)</source>
-          <target state="new">Current account used for watch (highlights / lowlights)</target>
+          <target state="needs-review">Текущий аккаунт для просмотра (хайлайты / лоулайты)</target>
         </trans-unit>
         <trans-unit id="CurrentFolder" translate="yes" xml:space="preserve">
           <source>Current folder</source>
-          <target state="new">Current folder</target>
+          <target state="needs-review">Текущая папка</target>
         </trans-unit>
         <trans-unit id="DataCache" translate="yes" xml:space="preserve">
           <source>Cache</source>
-          <target state="new">Cache</target>
+          <target state="needs-review">Кэш</target>
         </trans-unit>
         <trans-unit id="Date" translate="yes" xml:space="preserve">
           <source>Date</source>
-          <target state="new">Date</target>
+          <target state="needs-review">Дата</target>
         </trans-unit>
         <trans-unit id="DateFormat" translate="yes" xml:space="preserve">
           <source>Date Format</source>
-          <target state="new">Date Format</target>
+          <target state="needs-review">Формат Даты</target>
         </trans-unit>
         <trans-unit id="Deaths" translate="yes" xml:space="preserve">
           <source>Deaths</source>
-          <target state="new">Deaths</target>
+          <target state="needs-review">Смертей</target>
         </trans-unit>
         <trans-unit id="DemoName" translate="yes" xml:space="preserve">
           <source>Demo name</source>
-          <target state="new">Demo name</target>
+          <target state="needs-review">Имя демки</target>
         </trans-unit>
         <trans-unit id="Demos" translate="yes" xml:space="preserve">
           <source>Demo(s)</source>
-          <target state="new">Demo(s)</target>
+          <target state="needs-review">Демка(и)</target>
         </trans-unit>
         <trans-unit id="DemoType" translate="yes" xml:space="preserve">
           <source>Demo type</source>
-          <target state="new">Demo type</target>
+          <target state="needs-review">Тип демки</target>
         </trans-unit>
         <trans-unit id="DestinationFolderLabel" translate="yes" xml:space="preserve">
           <source>Destination folder</source>
-          <target state="new">Destination folder</target>
+          <target state="needs-review">Папка назначения</target>
         </trans-unit>
         <trans-unit id="Donation" translate="yes" xml:space="preserve">
           <source>donation</source>
-          <target state="new">donation</target>
+          <target state="needs-review">пожертвование</target>
         </trans-unit>
         <trans-unit id="Download" translate="yes" xml:space="preserve">
           <source>Download</source>
-          <target state="new">Download</target>
+          <target state="needs-review">Скачать</target>
         </trans-unit>
         <trans-unit id="HeaderDeathPerRound" translate="yes" xml:space="preserve">
           <source>DPR</source>
-          <target state="new">DPR</target>
+          <target state="needs-review">DPR</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Death Per Round</note>
         </trans-unit>
         <trans-unit id="DprFull" translate="yes" xml:space="preserve">
           <source>DPR (Death Per Round)</source>
-          <target state="new">DPR (Death Per Round)</target>
+          <target state="needs-review">DPR (Смертей за Раунд)</target>
         </trans-unit>
         <trans-unit id="Duration" translate="yes" xml:space="preserve">
           <source>Duration</source>
-          <target state="new">Duration</target>
+          <target state="needs-review">Длительность</target>
         </trans-unit>
         <trans-unit id="EntryKills" translate="yes" xml:space="preserve">
           <source>Entry kills</source>
-          <target state="new">Entry kills</target>
+          <target state="needs-review">Входных убийств</target>
         </trans-unit>
         <trans-unit id="EquipmentValueTeam1" translate="yes" xml:space="preserve">
           <source>Equipment value CT</source>
-          <target state="new">Equipment value CT</target>
+          <target state="needs-review">Цена экипировки КТ</target>
         </trans-unit>
         <trans-unit id="EquipmentValueTeam2" translate="yes" xml:space="preserve">
           <source>Equipment value T</source>
-          <target state="new">Equipment value T</target>
+          <target state="needs-review">Цена экипировки Т</target>
         </trans-unit>
         <trans-unit id="ExportCustomData" translate="yes" xml:space="preserve">
           <source>Export custom data</source>
-          <target state="new">Export custom data</target>
+          <target state="needs-review">Экспортировать выборочные данные</target>
         </trans-unit>
         <trans-unit id="FilterEtc" translate="yes" xml:space="preserve">
           <source>Filter...</source>
-          <target state="new">Filter...</target>
+          <target state="needs-review">Фильтр...</target>
         </trans-unit>
         <trans-unit id="HeaderFiveKills" translate="yes" xml:space="preserve">
           <source>5K</source>
-          <target state="new">5K</target>
+          <target state="needs-review">5У</target>
           <note from="MultilingualBuild" annotates="source" priority="2">5 Kills</note>
         </trans-unit>
         <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
-          <target state="new">Folders</target>
+          <target state="needs-review">Папки</target>
         </trans-unit>
         <trans-unit id="HeaderFourKills" translate="yes" xml:space="preserve">
           <source>4K</source>
-          <target state="new">4K</target>
+          <target state="needs-review">4У</target>
           <note from="MultilingualBuild" annotates="source" priority="2">4 Kills</note>
         </trans-unit>
         <trans-unit id="HeaderFramerate" translate="yes" xml:space="preserve">
           <source>FR</source>
-          <target state="new">FR</target>
+          <target state="needs-review">ФР</target>
         </trans-unit>
         <trans-unit id="From" translate="yes" xml:space="preserve">
           <source>From</source>
-          <target state="new">From</target>
+          <target state="needs-review">От</target>
         </trans-unit>
         <trans-unit id="Fullscreen" translate="yes" xml:space="preserve">
           <source>Fullscreen</source>
-          <target state="new">Fullscreen</target>
+          <target state="needs-review">Полноэкранный режим</target>
         </trans-unit>
         <trans-unit id="Height" translate="yes" xml:space="preserve">
           <source>Height</source>
-          <target state="new">Height</target>
+          <target state="needs-review">Высота</target>
         </trans-unit>
         <trans-unit id="HeaderHltvRating" translate="yes" xml:space="preserve">
           <source>HLTV</source>
-          <target state="new">HLTV</target>
+          <target state="needs-review">HLTV</target>
         </trans-unit>
         <trans-unit id="HeaderHltv2Rating" translate="yes" xml:space="preserve">
           <source>HLTV2</source>
-          <target state="new">HLTV2</target>
+          <target state="needs-review">HLTV2</target>
         </trans-unit>
         <trans-unit id="Hostname" translate="yes" xml:space="preserve">
           <source>Hostname</source>
-          <target state="new">Hostname</target>
+          <target state="needs-review">Сервер</target>
         </trans-unit>
         <trans-unit id="HeaderHeadshots" translate="yes" xml:space="preserve">
           <source>HS</source>
-          <target state="new">HS</target>
+          <target state="needs-review">УГ</target>
           <note from="MultilingualBuild" annotates="source" priority="2">HeadShot</note>
         </trans-unit>
         <trans-unit id="IgnoreBanOccuredAfterDemoDate" translate="yes" xml:space="preserve">
           <source>Ignore ban occured before demo date</source>
-          <target state="new">Ignore ban occured before demo date</target>
+          <target state="needs-review">Игнорировать бан, полученный до даты демки</target>
         </trans-unit>
         <trans-unit id="ImportCustomData" translate="yes" xml:space="preserve">
           <source>Import custom data</source>
-          <target state="new">Import custom data</target>
+          <target state="needs-review">Импортировать выборочные данные</target>
         </trans-unit>
         <trans-unit id="HeaderJumpKills" translate="yes" xml:space="preserve">
           <source>JK</source>
-          <target state="new">JK</target>
+          <target state="needs-review">УП</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Jump Kill</note>
         </trans-unit>
         <trans-unit id="JumpKills" translate="yes" xml:space="preserve">
           <source>Jump kills</source>
-          <target state="new">Jump kills</target>
+          <target state="needs-review">Убийств в прыжке</target>
         </trans-unit>
         <trans-unit id="HeaderKillDeathRatio" translate="yes" xml:space="preserve">
           <source>K/D</source>
-          <target state="new">K/D</target>
+          <target state="needs-review">У/С</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Kills Per Deaths</note>
         </trans-unit>
         <trans-unit id="Kills" translate="yes" xml:space="preserve">
           <source>Kills</source>
-          <target state="new">Kills</target>
+          <target state="needs-review">Убийств</target>
         </trans-unit>
         <trans-unit id="HeaderKillsPerRound" translate="yes" xml:space="preserve">
           <source>KPR</source>
-          <target state="new">KPR</target>
+          <target state="needs-review">УЗР</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Kill Per Round</note>
         </trans-unit>
         <trans-unit id="LaunchOptions" translate="yes" xml:space="preserve">
           <source>Launch Options</source>
-          <target state="new">Launch Options</target>
+          <target state="needs-review">Параметры Запуска</target>
         </trans-unit>
         <trans-unit id="LimitStatsToSelectedFolder" translate="yes" xml:space="preserve">
           <source>Limit stats to selected folder</source>
-          <target state="new">Limit stats to selected folder</target>
+          <target state="needs-review">Ограничить статистику выбранной папкой</target>
         </trans-unit>
         <trans-unit id="Map" translate="yes" xml:space="preserve">
           <source>Map</source>
-          <target state="new">Map</target>
+          <target state="needs-review">Карта</target>
         </trans-unit>
         <trans-unit id="MapName" translate="yes" xml:space="preserve">
           <source>Map name</source>
-          <target state="new">Map name</target>
+          <target state="needs-review">Имя карты</target>
         </trans-unit>
         <trans-unit id="Misc" translate="yes" xml:space="preserve">
           <source>Misc</source>
-          <target state="new">Misc</target>
+          <target state="needs-review">Разное</target>
         </trans-unit>
         <trans-unit id="MVP" translate="yes" xml:space="preserve">
           <source>MVP</source>
-          <target state="new">MVP</target>
+          <target state="needs-review">СЦИ</target>
         </trans-unit>
         <trans-unit id="Name" translate="yes" xml:space="preserve">
           <source>Name</source>
-          <target state="new">Name</target>
+          <target state="needs-review">Название</target>
         </trans-unit>
         <trans-unit id="NoAnalyzableDemos" translate="yes" xml:space="preserve">
           <source>No analyzable demos</source>
-          <target state="new">No analyzable demos</target>
+          <target state="needs-review">Нет демок для анализа</target>
         </trans-unit>
         <trans-unit id="NotAnalyzable" translate="yes" xml:space="preserve">
           <source>Not analyzable</source>
-          <target state="new">Not analyzable</target>
+          <target state="needs-review">Не анализируемо</target>
         </trans-unit>
         <trans-unit id="HeaderOneKill" translate="yes" xml:space="preserve">
           <source>1K</source>
-          <target state="new">1K</target>
+          <target state="needs-review">1У</target>
           <note from="MultilingualBuild" annotates="source" priority="2">1 Kill</note>
         </trans-unit>
         <trans-unit id="RemoveAccount" translate="yes" xml:space="preserve">
           <source>Remove account</source>
-          <target state="new">Remove account</target>
+          <target state="needs-review">Убрать аккаунт</target>
         </trans-unit>
         <trans-unit id="RemoveFolder" translate="yes" xml:space="preserve">
           <source>Remove folder</source>
-          <target state="new">Remove folder</target>
+          <target state="needs-review">Убрать папку</target>
         </trans-unit>
         <trans-unit id="RoundPlayed" translate="yes" xml:space="preserve">
           <source>Round played</source>
-          <target state="new">Round played</target>
+          <target state="needs-review">Раунд сыгран</target>
         </trans-unit>
         <trans-unit id="RoundType" translate="yes" xml:space="preserve">
           <source>Round type</source>
-          <target state="new">Round type</target>
+          <target state="needs-review">Тип раунда</target>
         </trans-unit>
         <trans-unit id="HeaderRoundPlayed" translate="yes" xml:space="preserve">
           <source>RP</source>
-          <target state="new">RP</target>
+          <target state="needs-review">РС</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Round Played</note>
         </trans-unit>
         <trans-unit id="RWS" translate="yes" xml:space="preserve">
           <source>RWS</source>
-          <target state="new">RWS</target>
+          <target state="needs-review">ВПР</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Round Win Share</note>
         </trans-unit>
         <trans-unit id="ScoreTeam1" translate="yes" xml:space="preserve">
           <source>Score team 1</source>
-          <target state="new">Score team 1</target>
+          <target state="needs-review">Счет команды 1</target>
         </trans-unit>
         <trans-unit id="ScoreTeam2" translate="yes" xml:space="preserve">
           <source>Score team 2</source>
-          <target state="new">Score team 2</target>
+          <target state="needs-review">Счет команды 2</target>
         </trans-unit>
         <trans-unit id="Settings" translate="yes" xml:space="preserve">
           <source>Settings</source>
-          <target state="new">Settings</target>
+          <target state="needs-review">Настройки</target>
         </trans-unit>
         <trans-unit id="ShowAllFolders" translate="yes" xml:space="preserve">
           <source>Show all folders</source>
-          <target state="new">Show all folders</target>
+          <target state="needs-review">Показать все папки</target>
         </trans-unit>
         <trans-unit id="ShowMoreDemos" translate="yes" xml:space="preserve">
           <source>Show More Demos</source>
-          <target state="new">Show More Demos</target>
+          <target state="needs-review">Показать Больше Демок</target>
         </trans-unit>
         <trans-unit id="SideTrouble" translate="yes" xml:space="preserve">
           <source>Side trouble</source>
-          <target state="new">Side trouble</target>
+          <target state="needs-review">Проблемная сторона</target>
         </trans-unit>
         <trans-unit id="Source" translate="yes" xml:space="preserve">
           <source>Source</source>
-          <target state="new">Source</target>
+          <target state="needs-review">Источник</target>
         </trans-unit>
         <trans-unit id="HeaderScoreTeam1" translate="yes" xml:space="preserve">
           <source>ST1</source>
-          <target state="new">ST1</target>
+          <target state="needs-review">СК1</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Score Team 1</note>
         </trans-unit>
         <trans-unit id="HeaderScoreTeam2" translate="yes" xml:space="preserve">
           <source>ST2</source>
-          <target state="new">ST2</target>
+          <target state="needs-review">СК2</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Score Team 2</note>
         </trans-unit>
         <trans-unit id="StartBotOnLaunch" translate="yes" xml:space="preserve">
           <source>Start BOT on launch</source>
-          <target state="new">Start BOT on launch</target>
+          <target state="needs-review">Запускать бота при старте CSGO-DM</target>
         </trans-unit>
         <trans-unit id="StartMoneyTeam1" translate="yes" xml:space="preserve">
           <source>Start money CT</source>
-          <target state="new">Start money CT</target>
+          <target state="needs-review">Стартовые деньги КТ</target>
         </trans-unit>
         <trans-unit id="StartMoneyTeam2" translate="yes" xml:space="preserve">
           <source>Start money T</source>
-          <target state="new">Start money T</target>
+          <target state="needs-review">Стартовые деньги Т</target>
         </trans-unit>
         <trans-unit id="Status" translate="yes" xml:space="preserve">
           <source>Status</source>
-          <target state="new">Status</target>
+          <target state="needs-review">Статус</target>
         </trans-unit>
         <trans-unit id="Stop" translate="yes" xml:space="preserve">
           <source>Stop</source>
-          <target state="new">Stop</target>
+          <target state="needs-review">Остановить</target>
         </trans-unit>
         <trans-unit id="SyncNicknames" translate="yes" xml:space="preserve">
           <source>Sync nicknames</source>
-          <target state="new">Sync nicknames</target>
+          <target state="needs-review">Синхронизировать никнеймы</target>
         </trans-unit>
         <trans-unit id="HeaderTotalDamagesArmor" translate="yes" xml:space="preserve">
           <source>TDA</source>
-          <target state="new">TDA</target>
+          <target state="needs-review">ВУБ</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Total Damage Armor</note>
         </trans-unit>
         <trans-unit id="HeaderTotalDamagesHealth" translate="yes" xml:space="preserve">
           <source>TDH</source>
-          <target state="new">TDH</target>
+          <target state="needs-review">ВУЗ</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Total Damage Health</note>
         </trans-unit>
         <trans-unit id="Team1" translate="yes" xml:space="preserve">
           <source>Team 1</source>
-          <target state="new">Team 1</target>
+          <target state="needs-review">Команда 1</target>
         </trans-unit>
         <trans-unit id="Team1Name" translate="yes" xml:space="preserve">
           <source>Team 1 name</source>
-          <target state="new">Team 1 name</target>
+          <target state="needs-review">Имя Команды 1</target>
         </trans-unit>
         <trans-unit id="Team2" translate="yes" xml:space="preserve">
           <source>Team 2</source>
-          <target state="new">Team 2</target>
+          <target state="needs-review">Команда 2</target>
         </trans-unit>
         <trans-unit id="Team2Name" translate="yes" xml:space="preserve">
           <source>Team 2 name</source>
-          <target state="new">Team 2 name</target>
+          <target state="needs-review">Имя Команды 2</target>
         </trans-unit>
         <trans-unit id="TeamTrouble" translate="yes" xml:space="preserve">
           <source>Team trouble</source>
-          <target state="new">Team trouble</target>
+          <target state="needs-review">Проблемная команда</target>
         </trans-unit>
         <trans-unit id="Theme" translate="yes" xml:space="preserve">
           <source>Theme</source>
-          <target state="new">Theme</target>
+          <target state="needs-review">Тема</target>
         </trans-unit>
         <trans-unit id="HeaderThreeKills" translate="yes" xml:space="preserve">
           <source>3K</source>
-          <target state="new">3K</target>
+          <target state="needs-review">3У</target>
           <note from="MultilingualBuild" annotates="source" priority="2">3 Kills</note>
         </trans-unit>
         <trans-unit id="HeaderTickrate" translate="yes" xml:space="preserve">
           <source>TR</source>
-          <target state="new">TR</target>
+          <target state="needs-review">ТР</target>
         </trans-unit>
         <trans-unit id="Ticks" translate="yes" xml:space="preserve">
           <source>Ticks</source>
-          <target state="new">Ticks</target>
+          <target state="needs-review">Тики</target>
         </trans-unit>
         <trans-unit id="TkFull" translate="yes" xml:space="preserve">
           <source>TK (Team Kill)</source>
-          <target state="new">TK (Team Kill)</target>
+          <target state="needs-review">СУ (Своих Убито)</target>
         </trans-unit>
         <trans-unit id="To" translate="yes" xml:space="preserve">
           <source>To</source>
-          <target state="new">To</target>
+          <target state="needs-review">До</target>
         </trans-unit>
         <trans-unit id="TotalDamageArmor" translate="yes" xml:space="preserve">
           <source>Total damage armor</source>
-          <target state="new">Total damage armor</target>
+          <target state="needs-review">Всего урона по броне</target>
         </trans-unit>
         <trans-unit id="TotalDamageHealth" translate="yes" xml:space="preserve">
           <source>Total damage health</source>
-          <target state="new">Total damage health</target>
+          <target state="needs-review">Всего урона по здоровью</target>
         </trans-unit>
         <trans-unit id="TotalKills" translate="yes" xml:space="preserve">
           <source>Total kills</source>
-          <target state="new">Total kills</target>
+          <target state="needs-review">Всего убийств</target>
         </trans-unit>
         <trans-unit id="ToWatch" translate="yes" xml:space="preserve">
           <source>To watch</source>
-          <target state="new">To watch</target>
+          <target state="needs-review">К просмотру</target>
         </trans-unit>
         <trans-unit id="TradeDeath" translate="yes" xml:space="preserve">
           <source>Trade death</source>
-          <target state="new">Trade death</target>
+          <target state="needs-review">Смертей в размен</target>
         </trans-unit>
         <trans-unit id="TradeKill" translate="yes" xml:space="preserve">
           <source>Trade kill</source>
-          <target state="new">Trade kill</target>
+          <target state="needs-review">Убийств в размен</target>
         </trans-unit>
         <trans-unit id="HeaderTwoKills" translate="yes" xml:space="preserve">
           <source>2K</source>
-          <target state="new">2K</target>
+          <target state="needs-review">2У</target>
           <note from="MultilingualBuild" annotates="source" priority="2">2 Kills</note>
         </trans-unit>
         <trans-unit id="Type" translate="yes" xml:space="preserve">
           <source>Type</source>
-          <target state="new">Type</target>
+          <target state="needs-review">Тип</target>
         </trans-unit>
         <trans-unit id="UseAccountForWatch" translate="yes" xml:space="preserve">
           <source>Use this account for watch</source>
-          <target state="new">Use this account for watch</target>
+          <target state="needs-review">Использовать этот аккаунт для просмотра</target>
         </trans-unit>
         <trans-unit id="UseCutomLowlightHighlight" translate="yes" xml:space="preserve">
           <source>Use custom highlights / lowlights generation</source>
-          <target state="new">Use custom highlights / lowlights generation</target>
+          <target state="needs-review">Использовать выборочную генерацию хайлайтов / лоулайтов</target>
         </trans-unit>
         <trans-unit id="Watched" translate="yes" xml:space="preserve">
           <source>Watched</source>
-          <target state="new">Watched</target>
+          <target state="needs-review">Просмотрена</target>
         </trans-unit>
         <trans-unit id="Width" translate="yes" xml:space="preserve">
           <source>Width</source>
-          <target state="new">Width</target>
+          <target state="needs-review">Ширина</target>
         </trans-unit>
         <trans-unit id="WinnerTeamName" translate="yes" xml:space="preserve">
           <source>Winner team name</source>
-          <target state="new">Winner team name</target>
+          <target state="needs-review">Выиграла команда</target>
         </trans-unit>
         <trans-unit id="WinnerSide" translate="yes" xml:space="preserve">
           <source>WS</source>
-          <target state="new">WS</target>
+          <target state="needs-review">ВС</target>
         </trans-unit>
         <trans-unit id="Yes" translate="yes" xml:space="preserve">
           <source>Yes</source>
-          <target state="new">Yes</target>
+          <target state="needs-review">Да</target>
         </trans-unit>
         <trans-unit id="ToolTipAccountStats" translate="yes" xml:space="preserve">
           <source>Account stats (CTRL+E)</source>
-          <target state="new">Account stats (CTRL+E)</target>
+          <target state="needs-review">Статистика аккаунта (CTRL+E)</target>
         </trans-unit>
         <trans-unit id="ToolTipAddToSuspectsList" translate="yes" xml:space="preserve">
           <source>Add players to suspects list (CTRL+W)</source>
-          <target state="new">Add players to suspects list (CTRL+W)</target>
+          <target state="needs-review">Добавить игроков в лист подозреваемых (CTRL+W)</target>
         </trans-unit>
         <trans-unit id="ToolTipAnalyzeSelectedDemos" translate="yes" xml:space="preserve">
           <source>Analyze selected demo(s) (CTRL+S)</source>
-          <target state="new">Analyze selected demo(s) (CTRL+S)</target>
+          <target state="needs-review">Проанализировать выбранную(ые) демку(и) (CTRL+S)</target>
         </trans-unit>
         <trans-unit id="ToolTipBrowseToDemo" translate="yes" xml:space="preserve">
           <source>Browse to demo (CTRL+B)</source>
-          <target state="new">Browse to demo (CTRL+B)</target>
+          <target state="needs-review">Расположение демки (CTRL+B)</target>
         </trans-unit>
         <trans-unit id="ToolTipDeleteDemo" translate="yes" xml:space="preserve">
           <source>Delete selected demo(s) (CTRL+D)</source>
-          <target state="new">Delete selected demo(s) (CTRL+D)</target>
+          <target state="needs-review">Удалить выбранную(ые) демку(и) (CTRL+D)</target>
         </trans-unit>
         <trans-unit id="ToolTipDemoDetails" translate="yes" xml:space="preserve">
           <source>Demo's details (CTRL+D)</source>
-          <target state="new">Demo's details (CTRL+D)</target>
+          <target state="needs-review">Подробности демки (CTRL+D)</target>
         </trans-unit>
         <trans-unit id="ToolTipDownloadDemos" translate="yes" xml:space="preserve">
           <source>Download last MM demos available for the current logged Steam account (CTRL+H)</source>
-          <target state="new">Download last MM demos available for the current logged Steam account (CTRL+H)</target>
+          <target state="needs-review">Скачать последние доступные ММ демки для текущего авторизованного в Steam аккаунта (CTRL+H)</target>
         </trans-unit>
         <trans-unit id="ToolTipExportXls" translate="yes" xml:space="preserve">
           <source>Export as XLS (CTRL+X)</source>
-          <target state="new">Export as XLS (CTRL+X)</target>
+          <target state="needs-review">Экспорт в XLS (CTRL+X)</target>
         </trans-unit>
         <trans-unit id="ToolTipGoToSuspectsList" translate="yes" xml:space="preserve">
           <source>Go to suspects list (CTRL+F)</source>
-          <target state="new">Go to suspects list (CTRL+F)</target>
+          <target state="needs-review">Перейти к списку подозреваемых (CTRL+F)</target>
         </trans-unit>
         <trans-unit id="ToolTipGotoTick" translate="yes" xml:space="preserve">
           <source>Start watching selected demo at specific tick (CTRL+G)</source>
-          <target state="new">Start watching selected demo at specific tick (CTRL+G)</target>
+          <target state="needs-review">Начать просмотр выбранной демки с определенного тика (CTRL+G)</target>
         </trans-unit>
         <trans-unit id="ToolTipRefreshDemosList" translate="yes" xml:space="preserve">
           <source>Refresh demos list (CTRL+R | F5)</source>
-          <target state="new">Refresh demos list (CTRL+R | F5)</target>
+          <target state="needs-review">Обновить список демок (CTRL+R | F5)</target>
         </trans-unit>
         <trans-unit id="ToolTipStop" translate="yes" xml:space="preserve">
           <source>Stop (CTRL+S)</source>
-          <target state="new">Stop (CTRL+S)</target>
+          <target state="needs-review">Остановить (CTRL+S)</target>
         </trans-unit>
         <trans-unit id="ToolTipWatchDemo" translate="yes" xml:space="preserve">
           <source>Watch demo (CTRL+W)</source>
-          <target state="new">Watch demo (CTRL+W)</target>
+          <target state="needs-review">Посмотреть демку (CTRL+W)</target>
         </trans-unit>
         <trans-unit id="ToolTipWatchHighlights" translate="yes" xml:space="preserve">
           <source>Watch your highlights (CTRL+H)</source>
-          <target state="new">Watch your highlights (CTRL+H)</target>
+          <target state="needs-review">Посмотреть ваши хайлайты (CTRL+H)</target>
         </trans-unit>
         <trans-unit id="ToolTipWatchLowlights" translate="yes" xml:space="preserve">
           <source>Watch your lowlights (CTRL+L)</source>
-          <target state="new">Watch your lowlights (CTRL+L)</target>
+          <target state="needs-review">Посмотреть ваши лоулайты (CTRL+L)</target>
         </trans-unit>
         <trans-unit id="Avatar" translate="yes" xml:space="preserve">
           <source>Avatar</source>
-          <target state="new">Avatar</target>
+          <target state="needs-review">Аватар</target>
         </trans-unit>
         <trans-unit id="CopyEmailAddress" translate="yes" xml:space="preserve">
           <source>Copy email address</source>
-          <target state="new">Copy email address</target>
+          <target state="needs-review">Скопировать адрес email</target>
         </trans-unit>
         <trans-unit id="Damages" translate="yes" xml:space="preserve">
           <source>Damages</source>
-          <target state="new">Damages</target>
+          <target state="needs-review">Схема урона</target>
         </trans-unit>
         <trans-unit id="Flashbangs" translate="yes" xml:space="preserve">
           <source>Flashbangs</source>
-          <target state="new">Flashbangs</target>
+          <target state="needs-review">Ослепления</target>
         </trans-unit>
         <trans-unit id="Heatmap" translate="yes" xml:space="preserve">
           <source>Heatmap</source>
-          <target state="new">Heatmap</target>
+          <target state="needs-review">Тепловая карта</target>
         </trans-unit>
         <trans-unit id="LabelClientname" translate="yes" xml:space="preserve">
           <source>Clientname</source>
-          <target state="new">Clientname</target>
+          <target state="needs-review">Клиент</target>
         </trans-unit>
         <trans-unit id="LabelFilename" translate="yes" xml:space="preserve">
           <source>Filename</source>
-          <target state="new">Filename</target>
+          <target state="needs-review">Файл</target>
         </trans-unit>
         <trans-unit id="LabelHostname" translate="yes" xml:space="preserve">
           <source>Hostname</source>
-          <target state="new">Hostname</target>
+          <target state="needs-review">Сервер</target>
         </trans-unit>
         <trans-unit id="LabelMostHsPercent" translate="yes" xml:space="preserve">
           <source>Most Headshots %</source>
-          <target state="new">Most Headshots %</target>
+          <target state="needs-review">Наибольший % убийств в голову</target>
         </trans-unit>
         <trans-unit id="LabelMap" translate="yes" xml:space="preserve">
           <source>Map</source>
-          <target state="new">Map</target>
+          <target state="needs-review">Карта</target>
         </trans-unit>
         <trans-unit id="LabelMostBombPlanted" translate="yes" xml:space="preserve">
           <source>Most Bomb plants</source>
-          <target state="new">Most Bomb plants</target>
+          <target state="needs-review">Больше всех ставил бомбу</target>
         </trans-unit>
         <trans-unit id="LabelMostDamagingWeapon" translate="yes" xml:space="preserve">
           <source>Most damaging weapon</source>
-          <target state="new">Most damaging weapon</target>
+          <target state="needs-review">Наибольший урон из оружия</target>
         </trans-unit>
         <trans-unit id="LabelMostEntryKills" translate="yes" xml:space="preserve">
           <source>Most Entry Kill</source>
-          <target state="new">Most Entry Kill</target>
+          <target state="needs-review">Больше всех входных убийств</target>
         </trans-unit>
         <trans-unit id="LabelMostKillingWeapon" translate="yes" xml:space="preserve">
           <source>Most killing weapon</source>
-          <target state="new">Most killing weapon</target>
+          <target state="needs-review">Самое убивающее оружие</target>
         </trans-unit>
         <trans-unit id="LabelPlayerStats" translate="yes" xml:space="preserve">
           <source>Player stats</source>
-          <target state="new">Player stats</target>
+          <target state="needs-review">Статистика игрока</target>
         </trans-unit>
         <trans-unit id="LabelStatus" translate="yes" xml:space="preserve">
           <source>Status</source>
-          <target state="new">Status</target>
+          <target state="needs-review">Статус</target>
         </trans-unit>
         <trans-unit id="LabelTickrate" translate="yes" xml:space="preserve">
           <source>Tickrate</source>
-          <target state="new">Tickrate</target>
+          <target state="needs-review">Тикрейт</target>
         </trans-unit>
         <trans-unit id="LabelType" translate="yes" xml:space="preserve">
           <source>Type</source>
-          <target state="new">Type</target>
+          <target state="needs-review">Тип</target>
         </trans-unit>
         <trans-unit id="Overview" translate="yes" xml:space="preserve">
           <source>Overview</source>
-          <target state="new">Overview</target>
+          <target state="needs-review">Обзор</target>
         </trans-unit>
         <trans-unit id="PlayerDetails" translate="yes" xml:space="preserve">
           <source>Player details</source>
-          <target state="new">Player details</target>
+          <target state="needs-review">Подробности игрока</target>
         </trans-unit>
         <trans-unit id="Rank" translate="yes" xml:space="preserve">
           <source>Rank</source>
-          <target state="new">Rank</target>
+          <target state="needs-review">Ранг</target>
         </trans-unit>
         <trans-unit id="RoundDetails" translate="yes" xml:space="preserve">
           <source>Round details</source>
-          <target state="new">Round details</target>
+          <target state="needs-review">Подробности раунда</target>
         </trans-unit>
         <trans-unit id="SaveComment" translate="yes" xml:space="preserve">
           <source>Save comment</source>
-          <target state="new">Save comment</target>
+          <target state="needs-review">Сохранить комментарий</target>
         </trans-unit>
         <trans-unit id="Score" translate="yes" xml:space="preserve">
           <source>Score</source>
-          <target state="new">Score</target>
+          <target state="needs-review">Счёт</target>
         </trans-unit>
         <trans-unit id="Stuffs" translate="yes" xml:space="preserve">
           <source>Stuffs</source>
-          <target state="new">Stuffs</target>
+          <target state="needs-review">Гранаты</target>
         </trans-unit>
         <trans-unit id="Tick" translate="yes" xml:space="preserve">
           <source>Tick</source>
-          <target state="new">Tick</target>
+          <target state="needs-review">Тик</target>
         </trans-unit>
         <trans-unit id="ToolTipAnalyze" translate="yes" xml:space="preserve">
           <source>Analyze (CTRL+S)</source>
-          <target state="new">Analyze (CTRL+S)</target>
+          <target state="needs-review">Анализ (CTRL+S)</target>
         </trans-unit>
         <trans-unit id="ToolTipBack" translate="yes" xml:space="preserve">
           <source>Back (CTRL+B)</source>
-          <target state="new">Back (CTRL+B)</target>
+          <target state="needs-review">Назад (CTRL+B)</target>
         </trans-unit>
         <trans-unit id="ToolTipDamages" translate="yes" xml:space="preserve">
           <source>Damages (CTRL+D)</source>
-          <target state="new">Damages (CTRL+D)</target>
+          <target state="needs-review">Схема урона (CTRL+D)</target>
         </trans-unit>
         <trans-unit id="ToolTipFlashbangs" translate="yes" xml:space="preserve">
           <source>Flashbangs (CTRL+F)</source>
-          <target state="new">Flashbangs (CTRL+F)</target>
+          <target state="needs-review">Ослепления (CTRL+F)</target>
         </trans-unit>
         <trans-unit id="ToolTipHeatmap" translate="yes" xml:space="preserve">
           <source>Heatmap generator (CTRL+H)</source>
-          <target state="new">Heatmap generator (CTRL+H)</target>
+          <target state="needs-review">Генератор тепловой карты (CTRL+H)</target>
         </trans-unit>
         <trans-unit id="ToolTipKillsDetails" translate="yes" xml:space="preserve">
           <source>Kills details (CTRL+K)</source>
-          <target state="new">Kills details (CTRL+K)</target>
+          <target state="needs-review">Подробности убийств (CTRL+K)</target>
         </trans-unit>
         <trans-unit id="ToolTipNextDemo" translate="yes" xml:space="preserve">
           <source>Next demo (CTRL+RIGHT)</source>
-          <target state="new">Next demo (CTRL+RIGHT)</target>
+          <target state="needs-review">Следующая демка (CTRL+RIGHT)</target>
         </trans-unit>
         <trans-unit id="ToolTipOverview" translate="yes" xml:space="preserve">
           <source>Overview (CTRL+O)</source>
-          <target state="new">Overview (CTRL+O)</target>
+          <target state="needs-review">Обзор (CTRL+O)</target>
         </trans-unit>
         <trans-unit id="ToolTipPlayerDetails" translate="yes" xml:space="preserve">
           <source>Player details (CTRL+P)</source>
-          <target state="new">Player details (CTRL+P)</target>
+          <target state="needs-review">Подробности игрока (CTRL+P)</target>
         </trans-unit>
         <trans-unit id="ToolTipPreviousDemo" translate="yes" xml:space="preserve">
           <source>Previous demo (CTRL+LEFT)</source>
-          <target state="new">Previous demo (CTRL+LEFT)</target>
+          <target state="needs-review">Предыдущая демка (CTRL+LEFT)</target>
         </trans-unit>
         <trans-unit id="ToolTipRoundDetails" translate="yes" xml:space="preserve">
           <source>Round details (CTRL+R)</source>
-          <target state="new">Round details (CTRL+R)</target>
+          <target state="needs-review">Подробности раунда (CTRL+R)</target>
         </trans-unit>
         <trans-unit id="ToolTipStuffs" translate="yes" xml:space="preserve">
           <source>Stuffs (CTRL+G)</source>
-          <target state="new">Stuffs (CTRL+G)</target>
+          <target state="needs-review">Гранаты (CTRL+G)</target>
         </trans-unit>
         <trans-unit id="ToolTipWatchRound" translate="yes" xml:space="preserve">
           <source>Watch round</source>
-          <target state="new">Watch round</target>
+          <target state="needs-review">Смотреть раунд</target>
         </trans-unit>
         <trans-unit id="WatchRound" translate="yes" xml:space="preserve">
           <source>Watch round</source>
-          <target state="new">Watch round</target>
+          <target state="needs-review">Смотреть раунд</target>
         </trans-unit>
         <trans-unit id="HeaderAssists" translate="yes" xml:space="preserve">
           <source>A</source>
-          <target state="new">A</target>
+          <target state="needs-review">П</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Assists</note>
         </trans-unit>
         <trans-unit id="HeaderAssistsPerRound" translate="yes" xml:space="preserve">
           <source>APR</source>
-          <target state="new">APR</target>
+          <target state="needs-review">ПЗР</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Assists Per Round</note>
         </trans-unit>
         <trans-unit id="HeaderAvarageDamagesPerPlayer" translate="yes" xml:space="preserve">
           <source>ADP</source>
-          <target state="new">ADP</target>
+          <target state="needs-review">СУИ</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Average Damages Per Player</note>
         </trans-unit>
         <trans-unit id="HeaderDeaths" translate="yes" xml:space="preserve">
           <source>D</source>
-          <target state="new">D</target>
+          <target state="needs-review">С</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Deaths</note>
         </trans-unit>
         <trans-unit id="HeaderEntryKills" translate="yes" xml:space="preserve">
           <source>EK</source>
-          <target state="new">EK</target>
+          <target state="needs-review">ВУ</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Entry Kills</note>
         </trans-unit>
         <trans-unit id="HeaderEquipementValueTeam1" translate="yes" xml:space="preserve">
           <source>EV CT ($)</source>
-          <target state="new">EV CT ($)</target>
+          <target state="needs-review">ЦЭ КТ($)</target>
         </trans-unit>
         <trans-unit id="HeaderEquipementValueTeam2" translate="yes" xml:space="preserve">
           <source>EV T ($)</source>
-          <target state="new">EV T ($)</target>
+          <target state="needs-review">ЦЭ Т ($)</target>
         </trans-unit>
         <trans-unit id="HeaderHsPercent" translate="yes" xml:space="preserve">
           <source>HS%</source>
-          <target state="new">HS%</target>
+          <target state="needs-review">УГ%</target>
           <note from="MultilingualBuild" annotates="source" priority="2">% headshot</note>
         </trans-unit>
         <trans-unit id="HeaderKills" translate="yes" xml:space="preserve">
           <source>K</source>
-          <target state="new">K</target>
+          <target state="needs-review">У</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Kills</note>
         </trans-unit>
         <trans-unit id="HeaderOverwatch" translate="yes" xml:space="preserve">
           <source>OW</source>
-          <target state="new">OW</target>
+          <target state="needs-review">ПТР</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Overwatch</note>
         </trans-unit>
         <trans-unit id="HeaderSideTrouble" translate="yes" xml:space="preserve">
           <source>ST</source>
-          <target state="new">ST</target>
+          <target state="needs-review">ПС</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Side Trouble</note>
         </trans-unit>
         <trans-unit id="HeaderStartMoneyTeam1" translate="yes" xml:space="preserve">
           <source>SM CT ($)</source>
-          <target state="new">SM CT ($)</target>
+          <target state="needs-review">СД КТ ($)</target>
         </trans-unit>
         <trans-unit id="HeaderStartMoneyTeam2" translate="yes" xml:space="preserve">
           <source>SM T ($)</source>
-          <target state="new">SM T ($)</target>
+          <target state="needs-review">СД Т ($)</target>
         </trans-unit>
         <trans-unit id="HeaderTeamKill" translate="yes" xml:space="preserve">
           <source>FF</source>
-          <target state="new">FF</target>
+          <target state="needs-review">ДС</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Team Kill</note>
         </trans-unit>
         <trans-unit id="HeaderTeamTrouble" translate="yes" xml:space="preserve">
           <source>TT</source>
-          <target state="new">TT</target>
+          <target state="needs-review">ПК</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Team Trouble</note>
         </trans-unit>
         <trans-unit id="HeaderToolTipAccountNickname" translate="yes" xml:space="preserve">
           <source>Account's Nickname</source>
-          <target state="new">Account's Nickname</target>
+          <target state="needs-review">Никнейм Аккаунта</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipAccountProfileUrl" translate="yes" xml:space="preserve">
           <source>Account's Profile URL</source>
-          <target state="new">Account's Profile URL</target>
+          <target state="needs-review">Ссылка на Профиль Аккаунта</target>>
         </trans-unit>
         <trans-unit id="HeaderToolTipAccountStatus" translate="yes" xml:space="preserve">
           <source>Account's Status (offline, online...)</source>
-          <target state="new">Account's Status (offline, online...)</target>
+          <target state="needs-review">Статус Аккаунта (оффлайн, онлайн...)</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipAccountVacBanned" translate="yes" xml:space="preserve">
           <source>Account VAC Banned</source>
-          <target state="new">Account VAC Banned</target>
+          <target state="needs-review">Аккаунт забанен VAC</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipAccountVisibilityStatus" translate="yes" xml:space="preserve">
           <source>Account's Visibility Status</source>
-          <target state="new">Account's Visibility Status</target>
+          <target state="needs-review">Статус Видимости Аккаунта</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipAssisterName" translate="yes" xml:space="preserve">
           <source>Assister Name</source>
-          <target state="new">Assister Name</target>
+          <target state="needs-review">Имя Помощника</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipAssists" translate="yes" xml:space="preserve">
           <source>Assists</source>
-          <target state="new">Assists</target>
+          <target state="needs-review">Помощей</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipAssistsPerRound" translate="yes" xml:space="preserve">
           <source>Assist Per Round</source>
-          <target state="new">Assist Per Round</target>
+          <target state="needs-review">Помощей за Раунд</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipAverageDamagePerPlayer" translate="yes" xml:space="preserve">
           <source>Average Damage Per Player</source>
-          <target state="new">Average Damage Per Player</target>
+          <target state="needs-review">Средний Урон Игрока</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipAverageDamagePerRound" translate="yes" xml:space="preserve">
           <source>Average Damage Per Round</source>
-          <target state="new">Average Damage Per Round</target>
+          <target state="needs-review">Средний Урон за Раунд</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipBombDefused" translate="yes" xml:space="preserve">
           <source>Bomb Defused</source>
-          <target state="new">Bomb Defused</target>
+          <target state="needs-review">Бомб Разминировано</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipBombExploded" translate="yes" xml:space="preserve">
           <source>Bomb Exploded</source>
-          <target state="new">Bomb Exploded</target>
+          <target state="needs-review">Бомб Взорвано</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipBombPlanted" translate="yes" xml:space="preserve">
           <source>Bomb Planted</source>
-          <target state="new">Bomb Planted</target>
+          <target state="needs-review">Бомб Установлено</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipClutchCount" translate="yes" xml:space="preserve">
           <source>Number of clutch</source>
-          <target state="new">Number of clutch</target>
+          <target state="needs-review">Число клатчей</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipClutchWonCount" translate="yes" xml:space="preserve">
           <source>Number of clutch won</source>
-          <target state="new">Number of clutch won</target>
+          <target state="needs-review">Число выигранных клатчей</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipCommunityBanned" translate="yes" xml:space="preserve">
           <source>Community Banned</source>
-          <target state="new">Community Banned</target>
+          <target state="needs-review">Забанен в Сообществе</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipCommunityProfileConfigured" translate="yes" xml:space="preserve">
           <source>Community Profile Configured</source>
-          <target state="new">Community Profile Configured</target>
+          <target state="needs-review">Профиль Сообщества Настроен</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipCrouchKills" translate="yes" xml:space="preserve">
           <source>Crouch kills</source>
-          <target state="new">Crouch kills</target>
+          <target state="needs-review">Убийств сидя</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipDaysSinceLastBan" translate="yes" xml:space="preserve">
           <source>Days Since Last Ban</source>
-          <target state="new">Days Since Last Ban</target>
+          <target state="needs-review">Дней с Последнего Бана</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipDeaths" translate="yes" xml:space="preserve">
           <source>Deaths</source>
-          <target state="new">Deaths</target>
+          <target state="needs-review">Смертей</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipDeathsPerRound" translate="yes" xml:space="preserve">
           <source>Death Per Round</source>
-          <target state="new">Death Per Round</target>
+          <target state="needs-review">Смертей за Раунд</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipDemoClientname" translate="yes" xml:space="preserve">
           <source>Demo's clientname</source>
-          <target state="new">Demo's clientname</target>
+          <target state="needs-review">Клиент демки</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipDemoComment" translate="yes" xml:space="preserve">
           <source>Demo's comment</source>
-          <target state="new">Demo's comment</target>
+          <target state="needs-review">Комментарии к демке</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipDemoDate" translate="yes" xml:space="preserve">
           <source>Demo's date</source>
-          <target state="new">Demo's date</target>
+          <target state="needs-review">Дата демки</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipDemoDuration" translate="yes" xml:space="preserve">
           <source>Demo's duration</source>
-          <target state="new">Demo's duration</target>
+          <target state="needs-review">Длительность демки</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipDemoFramerate" translate="yes" xml:space="preserve">
           <source>Demo's framerate</source>
-          <target state="new">Demo's framerate</target>
+          <target state="needs-review">Фреймрейт демки</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipDemoHostname" translate="yes" xml:space="preserve">
           <source>Demo's hostname</source>
-          <target state="new">Demo's hostname</target>
+          <target state="needs-review">Сервер демки</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipDemoName" translate="yes" xml:space="preserve">
           <source>Demo's name</source>
-          <target state="new">Demo's name</target>
+          <target state="needs-review">Имя демки</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipDemoSource" translate="yes" xml:space="preserve">
           <source>Demo's source</source>
-          <target state="new">Demo's source</target>
+          <target state="needs-review">Источник демки</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipDemoTicks" translate="yes" xml:space="preserve">
           <source>Demo's ticks</source>
-          <target state="new">Demo's ticks</target>
+          <target state="needs-review">Тики демки</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipDemoType" translate="yes" xml:space="preserve">
           <source>Demo's type</source>
-          <target state="new">Demo's type</target>
+          <target state="needs-review">Тип демки</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipEntryKill" translate="yes" xml:space="preserve">
           <source>Entry Kill</source>
-          <target state="new">Entry Kill</target>
+          <target state="needs-review">Входных Убийств</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipEquipmentValue" translate="yes" xml:space="preserve">
           <source>Equipment Value</source>
-          <target state="new">Equipment Value</target>
+          <target state="needs-review">Цена Экипировки</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipEquipmentValueTeam1" translate="yes" xml:space="preserve">
           <source>Equipement Value CT ($)</source>
-          <target state="new">Equipement Value CT ($)</target>
+          <target state="needs-review">Цена Экипировки КТ ($)</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipEquipmentValueTeam2" translate="yes" xml:space="preserve">
           <source>Equipement Value T ($)</source>
-          <target state="new">Equipement Value T ($)</target>
+          <target state="needs-review">Цена Экипировки Т ($)</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipFiveKill" translate="yes" xml:space="preserve">
           <source>5 Kills</source>
-          <target state="new">5 Kills</target>
+          <target state="needs-review">5 Убийств</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipFourKill" translate="yes" xml:space="preserve">
           <source>4 Kills</source>
-          <target state="new">4 Kills</target>
+          <target state="needs-review">4 Убийства</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipHasVacOwBan" translate="yes" xml:space="preserve">
           <source>VAC / OW ban?</source>
-          <target state="new">VAC / OW ban?</target>
+          <target state="needs-review">VAC / Патруль бан?</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipHasWonClutch" translate="yes" xml:space="preserve">
           <source>Has Won Clutch?</source>
-          <target state="new">Has Won Clutch?</target>
+          <target state="needs-review">Выиграл Клатч?</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipHasWonDuel" translate="yes" xml:space="preserve">
           <source>Has Won Duel?</source>
-          <target state="new">Has Won Duel?</target>
+          <target state="needs-review">Выиграл Дуэль?</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipHeadshotPercent" translate="yes" xml:space="preserve">
           <source>Headshot percent</source>
-          <target state="new">Headshot percent</target>
+          <target state="needs-review">Процент убийств в голову</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipHeadshots" translate="yes" xml:space="preserve">
           <source>Headshots</source>
-          <target state="new">Headshots</target>
+          <target state="needs-review">Убийств в голову</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipHits" translate="yes" xml:space="preserve">
           <source>Hits</source>
-          <target state="new">Hits</target>
+          <target state="needs-review">Попаданий</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipHltvRating" translate="yes" xml:space="preserve">
           <source>HLTV Rating</source>
-          <target state="new">HLTV Rating</target>
+          <target state="needs-review">HLTV Рейтинг</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipHltv2Rating" translate="yes" xml:space="preserve">
           <source>HLTV2 Rating</source>
-          <target state="new">HLTV2 Rating</target>
+          <target state="needs-review">HLTV2 Рейтинг</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipIsOwBanned" translate="yes" xml:space="preserve">
           <source>Overwatch banned?</source>
-          <target state="new">Overwatch banned?</target>
+          <target state="needs-review">Забанен Патрулем?</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipIsVacBanned" translate="yes" xml:space="preserve">
           <source>VAC banned?</source>
-          <target state="new">VAC banned?</target>
+          <target state="needs-review">Забанен VAC?</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipJumpKills" translate="yes" xml:space="preserve">
           <source>Jump Kills</source>
-          <target state="new">Jump Kills</target>
+          <target state="needs-review">Убийств в Прыжке</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipKillerName" translate="yes" xml:space="preserve">
           <source>Killer Name</source>
-          <target state="new">Killer Name</target>
+          <target state="needs-review">Имя Убийцы</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipKillerSide" translate="yes" xml:space="preserve">
           <source>Killer Side</source>
-          <target state="new">Killer Side</target>
+          <target state="needs-review">/Сторона Убийцы</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipKillPerRound" translate="yes" xml:space="preserve">
           <source>Kill Per Round</source>
-          <target state="new">Kill Per Round</target>
+          <target state="needs-review">Убийств за Раунд</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipKills" translate="yes" xml:space="preserve">
           <source>Kills</source>
-          <target state="new">Kills</target>
+          <target state="needs-review">Убийств</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipKillsPerDeaths" translate="yes" xml:space="preserve">
           <source>Kills Per Deaths</source>
-          <target state="new">Kills Per Deaths</target>
+          <target state="needs-review">Убийств / Смертей</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipMapName" translate="yes" xml:space="preserve">
           <source>Map's name</source>
-          <target state="new">Map's name</target>
+          <target state="needs-review">Имя карты</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipMarketBanned" translate="yes" xml:space="preserve">
           <source>Market Banned</source>
-          <target state="new">Market Banned</target>
+          <target state="needs-review">Забанен Маркетом</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipMvp" translate="yes" xml:space="preserve">
           <source>Most Valuable Player</source>
-          <target state="new">Most Valuable Player</target>
+          <target state="needs-review">Самый Ценный Игрок</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipNumber" translate="yes" xml:space="preserve">
           <source>Number</source>
-          <target state="new">Number</target>
+          <target state="needs-review">Число</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipOneKill" translate="yes" xml:space="preserve">
           <source>1 Kill</source>
-          <target state="new">1 Kill</target>
+          <target state="needs-review">1 Убийство</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipOneVersusFive" translate="yes" xml:space="preserve">
           <source>1 versus 5</source>
-          <target state="new">1 versus 5</target>
+          <target state="needs-review">1 против 5</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipOneVersusFour" translate="yes" xml:space="preserve">
           <source>1 versus 4</source>
-          <target state="new">1 versus 4</target>
+          <target state="needs-review">1 против 4</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipOneVersusOne" translate="yes" xml:space="preserve">
           <source>1 versus 1</source>
-          <target state="new">1 versus 1</target>
+          <target state="needs-review">1 против 1</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipOneVersusThree" translate="yes" xml:space="preserve">
           <source>1 versus 3</source>
-          <target state="new">1 versus 3</target>
+          <target state="needs-review">1 против 3</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipOneVersusTwo" translate="yes" xml:space="preserve">
           <source>1 versus 2</source>
-          <target state="new">1 versus 2</target>
+          <target state="needs-review">1 против 2</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipOneVersusX" translate="yes" xml:space="preserve">
           <source>1vX</source>
-          <target state="new">1vX</target>
+          <target state="needs-review">1вХ</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipOverwatchGameBanCount" translate="yes" xml:space="preserve">
           <source>Number of overwatch ban</source>
-          <target state="new">Number of overwatch ban</target>
+          <target state="needs-review">Число банов Патрулем</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipPlayerAvatar" translate="yes" xml:space="preserve">
           <source>Player's avatar</source>
-          <target state="new">Player's avatar</target>
+          <target state="needs-review">Аватар игрока</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipPlayerFlashbangThrown" translate="yes" xml:space="preserve">
           <source>Total flashbang thrown by the player</source>
-          <target state="new">Total flashbang thrown by the player</target>
+          <target state="needs-review">Всего световых брошено игроком</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipPlayerName" translate="yes" xml:space="preserve">
           <source>Player's name</source>
-          <target state="new">Player's name</target>
+          <target state="needs-review">Имя игрока</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipPlayerRank" translate="yes" xml:space="preserve">
           <source>Player's rank</source>
-          <target state="new">Player's rank</target>
+          <target state="needs-review">Ранг игрока</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipRatio" translate="yes" xml:space="preserve">
           <source>Ratio</source>
-          <target state="new">Ratio</target>
+          <target state="needs-review">Соотношение</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipResult" translate="yes" xml:space="preserve">
           <source>Result</source>
-          <target state="new">Result</target>
+          <target state="needs-review">Итог</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipRoundLost" translate="yes" xml:space="preserve">
           <source>Round Lost</source>
-          <target state="new">Round Lost</target>
+          <target state="needs-review">Раундов Проиграно</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipRoundNumber" translate="yes" xml:space="preserve">
           <source>Round Number</source>
-          <target state="new">Round Number</target>
+          <target state="needs-review">Число Раундов</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipRoundPlayed" translate="yes" xml:space="preserve">
           <source>Round Played</source>
-          <target state="new">Round Played</target>
+          <target state="needs-review">Раундов Сыграно</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipRoundType" translate="yes" xml:space="preserve">
           <source>Round Type (normal / eco / force buy / semi-eco)</source>
-          <target state="new">Round Type (normal / eco / force buy / semi-eco)</target>
+          <target state="needs-review">Тип Раунда (Норм / Эко / Форсбай / Полу-эко)</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipRoundWon" translate="yes" xml:space="preserve">
           <source>Round Won</source>
-          <target state="new">Round Won</target>
+          <target state="needs-review">Раундов Выиграно</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipRws" translate="yes" xml:space="preserve">
           <source>ESEA RWS (Round Win Share)</source>
-          <target state="new">ESEA RWS (Round Win Share)</target>
+          <target state="needs-review">ESEA ВПР (Вклад в Победу в Раунде)</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipScore" translate="yes" xml:space="preserve">
           <source>Score</source>
-          <target state="new">Score</target>
+          <target state="needs-review">Счёт</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipScoreTeam1" translate="yes" xml:space="preserve">
           <source>Score Team 1</source>
-          <target state="new">Score Team 1</target>
+          <target state="needs-review">Счёт Команды 1</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipScoreTeam2" translate="yes" xml:space="preserve">
           <source>Score Team 2</source>
-          <target state="new">Score Team 2</target>
+          <target state="needs-review">Счёт Команды 2</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipServerTickrate" translate="yes" xml:space="preserve">
           <source>Server tickrate</source>
-          <target state="new">Server tickrate</target>
+          <target state="needs-review">Тикрейт сервера</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipShotsFired" translate="yes" xml:space="preserve">
           <source>Shots fired</source>
-          <target state="new">Shots fired</target>
+          <target state="needs-review">Выстрелов</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipSideTrouble" translate="yes" xml:space="preserve">
           <source>Side on eco / force buy or semi-eco</source>
-          <target state="new">Side on eco / force buy or semi-eco</target>
+          <target state="needs-review">Сторона на эко / форсбае или полу-эко</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipStartMoney" translate="yes" xml:space="preserve">
           <source>Start Money</source>
-          <target state="new">Start Money</target>
+          <target state="needs-review">Стартовые Деньги</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipStartMoneyTeam1" translate="yes" xml:space="preserve">
           <source>Start Money CT ($)</source>
-          <target state="new">Start Money CT ($)</target>
+          <target state="needs-review">Стартовые Деньги КТ ($)</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipStartMoneyTeam2" translate="yes" xml:space="preserve">
           <source>Start Money T ($)</source>
-          <target state="new">Start Money T ($)</target>
+          <target state="needs-review">Стартовые Деньги Т ($)</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTeam1Name" translate="yes" xml:space="preserve">
           <source>Team 1 name</source>
-          <target state="new">Team 1 name</target>
+          <target state="needs-review">Имя команды 1</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTeam2Name" translate="yes" xml:space="preserve">
           <source>Team 2 name</source>
-          <target state="new">Team 2 name</target>
+          <target state="needs-review">Имя команды 2</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTeamFlashbangThrown" translate="yes" xml:space="preserve">
           <source>Total flashbang thrown by the team</source>
-          <target state="new">Total flashbang thrown by the team</target>
+          <target state="needs-review">Всего световых брошено командой</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTeamKill" translate="yes" xml:space="preserve">
           <source>Team Kill (Friendly Fire)</source>
-          <target state="new">Team Kill (Friendly Fire)</target>
+          <target state="needs-review">Своих Убито (Дружественный Огонь)</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTeamName" translate="yes" xml:space="preserve">
           <source>Team Name</source>
-          <target state="new">Team Name</target>
+          <target state="needs-review">Имя Команды</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTeamNameTrouble" translate="yes" xml:space="preserve">
           <source>Team's name on eco / force buy or semi-eco</source>
-          <target state="new">Team's name on eco / force buy or semi-eco</target>
+          <target state="needs-review">Команда на эко / форсбае или полу-эко</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipThreeKill" translate="yes" xml:space="preserve">
           <source>3 Kills</source>
-          <target state="new">3 Kills</target>
+          <target state="needs-review">3 Убийства</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipThrowerName" translate="yes" xml:space="preserve">
           <source>Thrower Name</source>
-          <target state="new">Thrower Name</target>
+          <target state="needs-review">Имя Бросающего</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTick" translate="yes" xml:space="preserve">
           <source>Tick</source>
-          <target state="new">Tick</target>
+          <target state="needs-review">Тик</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTotalDamageArmor" translate="yes" xml:space="preserve">
           <source>Total Damage Armor</source>
-          <target state="new">Total Damage Armor</target>
+          <target state="needs-review">Всего Урона по Броне</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTotalDamageHealth" translate="yes" xml:space="preserve">
           <source>Total Damage Health</source>
-          <target state="new">Total Damage Health</target>
+          <target state="needs-review">Всего Урона по Здоровью</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTotalEntryKill" translate="yes" xml:space="preserve">
           <source>Total Entry Kill</source>
-          <target state="new">Total Entry Kill</target>
+          <target state="needs-review">Всего Входных Убийств</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTradeDeath" translate="yes" xml:space="preserve">
           <source>Trade death</source>
-          <target state="new">Trade death</target>
+          <target state="needs-review">Смертей в размен</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTradeKill" translate="yes" xml:space="preserve">
           <source>Trade kill</source>
-          <target state="new">Trade kill</target>
+          <target state="needs-review">Убийств в размен</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTradeKillsDeaths" translate="yes" xml:space="preserve">
           <source>Trade Kill / Death</source>
-          <target state="new">Trade Kill / Death</target>
+          <target state="needs-review">Убийств в размен / Смертей</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTwoKill" translate="yes" xml:space="preserve">
           <source>2 Kills</source>
-          <target state="new">2 Kills</target>
+          <target state="needs-review">2 Убийства</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipVacBanCount" translate="yes" xml:space="preserve">
           <source>Number of VAC ban</source>
-          <target state="new">Number of VAC ban</target>
+          <target state="needs-review">Число банов VAC</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipVictimName" translate="yes" xml:space="preserve">
           <source>Victim Name</source>
-          <target state="new">Victim Name</target>
+          <target state="needs-review">Имя Жертвы</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipWeaponName" translate="yes" xml:space="preserve">
           <source>Weapon's name</source>
-          <target state="new">Weapon's name</target>
+          <target state="needs-review">Оружие</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipWinner" translate="yes" xml:space="preserve">
           <source>Winner</source>
-          <target state="new">Winner</target>
+          <target state="needs-review">Победитель</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipWinnerTeamName" translate="yes" xml:space="preserve">
           <source>Winner Team Name</source>
-          <target state="new">Winner Team Name</target>
+          <target state="needs-review">Выиграла Команда</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipWinStatus" translate="yes" xml:space="preserve">
           <source>Win/Lose/Draw</source>
-          <target state="new">Win/Lose/Draw</target>
+          <target state="needs-review">Победа/Проигрыш/Ничья</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipWonRound" translate="yes" xml:space="preserve">
           <source>Round Won?</source>
-          <target state="new">Round Won?</target>
+          <target state="needs-review">Раунд выигран?</target>
         </trans-unit>
         <trans-unit id="HeaderTradeDeaths" translate="yes" xml:space="preserve">
           <source>TD</source>
-          <target state="new">TD</target>
+          <target state="needs-review">СР</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Trade Deaths</note>
         </trans-unit>
         <trans-unit id="HeaderTradeKills" translate="yes" xml:space="preserve">
           <source>TK</source>
-          <target state="new">TK</target>
+          <target state="needs-review">УР</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Trade Kills</note>
         </trans-unit>
         <trans-unit id="HeaderWinnerSide" translate="yes" xml:space="preserve">
           <source>WS</source>
-          <target state="new">WS</target>
+          <target state="needs-review">ВС</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Winner Side</note>
         </trans-unit>
         <trans-unit id="HeaderWinnerTeamName" translate="yes" xml:space="preserve">
           <source>WTN</source>
-          <target state="new">WTN</target>
+          <target state="needs-review">ВК</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Winner Team Name</note>
         </trans-unit>
         <trans-unit id="OneVersusFive" translate="yes" xml:space="preserve">
           <source>1V5</source>
-          <target state="new">1V5</target>
+          <target state="needs-review">1в5</target>
         </trans-unit>
         <trans-unit id="OneVersusFour" translate="yes" xml:space="preserve">
           <source>1V4</source>
-          <target state="new">1V4</target>
+          <target state="needs-review">1в4</target>
         </trans-unit>
         <trans-unit id="OneVersusOne" translate="yes" xml:space="preserve">
           <source>1V1</source>
-          <target state="new">1V1</target>
+          <target state="needs-review">1в1</target>
         </trans-unit>
         <trans-unit id="OneVersusThree" translate="yes" xml:space="preserve">
           <source>1V3</source>
-          <target state="new">1V3</target>
+          <target state="needs-review">1в3</target>
         </trans-unit>
         <trans-unit id="OneVersusTwo" translate="yes" xml:space="preserve">
           <source>1V2</source>
-          <target state="new">1V2</target>
+          <target state="needs-review">1в2</target>
         </trans-unit>
         <trans-unit id="Player" translate="yes" xml:space="preserve">
           <source>Player</source>
-          <target state="new">Player</target>
+          <target state="needs-review">Игрок</target>
         </trans-unit>
         <trans-unit id="HeaderClutchs" translate="yes" xml:space="preserve">
           <source>C</source>
-          <target state="new">C</target>
+          <target state="needs-review">К</target>
         </trans-unit>
         <trans-unit id="AddPlayersToSuspects" translate="yes" xml:space="preserve">
           <source>Add players to suspects list</source>
-          <target state="new">Add players to suspects list</target>
+          <target state="needs-review">Добавить игроков в список подозреваемых</target>
         </trans-unit>
         <trans-unit id="AddToAccountList" translate="yes" xml:space="preserve">
           <source>Add to account list</source>
-          <target state="new">Add to account list</target>
+          <target state="needs-review">Добавить в список аккаунтов</target>
         </trans-unit>
         <trans-unit id="AddToWhitelist" translate="yes" xml:space="preserve">
           <source>Add to whitelist</source>
-          <target state="new">Add to whitelist</target>
+          <target state="needs-review">Добавить в белый список</target>
         </trans-unit>
         <trans-unit id="AssistsFull" translate="yes" xml:space="preserve">
           <source>A (Assits)</source>
-          <target state="new">A (Assits)</target>
+          <target state="needs-review">П (Помощей)</target>
         </trans-unit>
         <trans-unit id="BombDefusedFull" translate="yes" xml:space="preserve">
           <source>BD (Bomb Defused)</source>
-          <target state="new">BD (Bomb Defused)</target>
+          <target state="needs-review">БР (Бомб Разминировано)</target>
         </trans-unit>
         <trans-unit id="BombExplodedFull" translate="yes" xml:space="preserve">
           <source>BE (Bomb Exploded)</source>
-          <target state="new">BE (Bomb Exploded)</target>
+          <target state="needs-review">БВ (Бомб Взорвано)</target>
         </trans-unit>
         <trans-unit id="BombPlantedFull" translate="yes" xml:space="preserve">
           <source>BP (Bomb Planted)</source>
-          <target state="new">BP (Bomb Planted)</target>
+          <target state="needs-review">БУ (Бомб Установлено)</target>
         </trans-unit>
         <trans-unit id="ClutchsFull" translate="yes" xml:space="preserve">
           <source>C (Clutchs)</source>
-          <target state="new">C (Clutchs)</target>
+          <target state="needs-review">К (Клатчей)</target>
         </trans-unit>
         <trans-unit id="CopyPlayDemoCommand" translate="yes" xml:space="preserve">
           <source>Copy playdemo command</source>
-          <target state="new">Copy playdemo command</target>
+          <target state="needs-review">Скопировать команду playdemo</target>
         </trans-unit>
         <trans-unit id="CrouchKillsFull" translate="yes" xml:space="preserve">
           <source>CK (Crouch Kills)</source>
-          <target state="new">CK (Crouch Kills)</target>
+          <target state="needs-review">УС (Убийств Сидя)</target>
         </trans-unit>
         <trans-unit id="DeathsFull" translate="yes" xml:space="preserve">
           <source>D (Deaths)</source>
-          <target state="new">D (Deaths)</target>
+          <target state="needs-review">С (Смертей)</target>
         </trans-unit>
         <trans-unit id="EntryKillsFull" translate="yes" xml:space="preserve">
           <source>EK (Entry Kills)</source>
-          <target state="new">EK (Entry Kills)</target>
+          <target state="needs-review">ВУ (Входных Убийств)</target>
         </trans-unit>
         <trans-unit id="EquipmentValueTeam1Full" translate="yes" xml:space="preserve">
           <source>EV CT (Equipment Value CT ($))</source>
-          <target state="new">EV CT (Equipment Value CT ($))</target>
+          <target state="needs-review">ЦЭ КТ (Цена Экипировки КТ ($))</target>
         </trans-unit>
         <trans-unit id="EquipmentValueTeam2Full" translate="yes" xml:space="preserve">
           <source>EV T (Equipment Value T ($))</source>
-          <target state="new">EV T (Equipment Value T ($))</target>
+          <target state="needs-review">ЦЭ Т (Цена Экипировки Т ($))</target>
         </trans-unit>
         <trans-unit id="EseaRwsFull" translate="yes" xml:space="preserve">
           <source>RWS (ESEA Round Win Share)</source>
-          <target state="new">RWS (ESEA Round Win Share)</target>
+          <target state="needs-review">ВПР (ESEA Вклад в Победу в Раунде)</target>
         </trans-unit>
         <trans-unit id="ExportJson" translate="yes" xml:space="preserve">
           <source>Export JSON</source>
-          <target state="new">Export JSON</target>
+          <target state="needs-review">Экспорт JSON</target>
         </trans-unit>
         <trans-unit id="Framerate" translate="yes" xml:space="preserve">
           <source>Framerate</source>
-          <target state="new">Framerate</target>
+          <target state="needs-review">Фреймрейт</target>
         </trans-unit>
         <trans-unit id="FramerateFull" translate="yes" xml:space="preserve">
           <source>FR (Framerate)</source>
-          <target state="new">FR (Framerate)</target>
+          <target state="needs-review">ФР (Фреймрейт)</target>
         </trans-unit>
         <trans-unit id="HeadshotsFull" translate="yes" xml:space="preserve">
           <source>HS (Headshots)</source>
-          <target state="new">HS (Headshots)</target>
+          <target state="needs-review">УГ (Убийств в голову)</target>
         </trans-unit>
         <trans-unit id="HltvFull" translate="yes" xml:space="preserve">
           <source>HLTV (HLTV Rating)</source>
-          <target state="new">HLTV (HLTV Rating)</target>
+          <target state="needs-review">HLTV (HLTV Рейтинг)</target>
         </trans-unit>
         <trans-unit id="Hltv2Full" translate="yes" xml:space="preserve">
           <source>HLTV2 (HLTV2 Rating)</source>
-          <target state="new">HLTV2 (HLTV2 Rating)</target>
+          <target state="needs-review">HLTV2 (HLTV2 Рейтинг)</target>
         </trans-unit>
         <trans-unit id="JumpKillsFull" translate="yes" xml:space="preserve">
           <source>JK (Jump Kills)</source>
-          <target state="new">JK (Jump Kills)</target>
+          <target state="needs-review">УП (Убийств в Прыжке)</target>
         </trans-unit>
         <trans-unit id="KillsDeathsRatioFull" translate="yes" xml:space="preserve">
           <source>K/D (Kills per Deaths)</source>
-          <target state="new">K/D (Kills per Deaths)</target>
+          <target state="needs-review">У/С (Убийств / Смертей)</target>
         </trans-unit>
         <trans-unit id="KillsFull" translate="yes" xml:space="preserve">
           <source>K (Kills)</source>
-          <target state="new">K (Kills)</target>
+          <target state="needs-review">У (Убийств)</target>
         </trans-unit>
         <trans-unit id="LastRankDetected" translate="yes" xml:space="preserve">
           <source>Last rank detected</source>
-          <target state="new">Last rank detected</target>
+          <target state="needs-review">Последний известный ранг</target>
         </trans-unit>
         <trans-unit id="MoveToWhitelist" translate="yes" xml:space="preserve">
           <source>Move to whitelist</source>
-          <target state="new">Move to whitelist</target>
+          <target state="needs-review">Переместить в белый список</target>
         </trans-unit>
         <trans-unit id="MvpFull" translate="yes" xml:space="preserve">
           <source>MVP (Most Valuable Player)</source>
-          <target state="new">MVP (Most Valuable Player)</target>
+          <target state="needs-review">СЦИ (Самый Ценный Игрок)</target>
         </trans-unit>
         <trans-unit id="Profile" translate="yes" xml:space="preserve">
           <source>Profile</source>
-          <target state="new">Profile</target>
+          <target state="needs-review">Профиль</target>
         </trans-unit>
         <trans-unit id="Remove" translate="yes" xml:space="preserve">
           <source>Remove</source>
-          <target state="new">Remove</target>
+          <target state="needs-review">Убрать</target>
         </trans-unit>
         <trans-unit id="RemoveFromCache" translate="yes" xml:space="preserve">
           <source>Remove from cache</source>
-          <target state="new">Remove from cache</target>
+          <target state="needs-review">Убрать из кэша</target>
         </trans-unit>
         <trans-unit id="RoundPlayedFull" translate="yes" xml:space="preserve">
           <source>RP (Round Played)</source>
-          <target state="new">RP (Round Played)</target>
+          <target state="needs-review">РС (Раундов Сыграно)</target>
         </trans-unit>
         <trans-unit id="ScoreTeam1Full" translate="yes" xml:space="preserve">
           <source>ST1 (Score Team 1)</source>
-          <target state="new">ST1 (Score Team 1)</target>
+          <target state="needs-review">СК1 (Счёт Команды 1)</target>
         </trans-unit>
         <trans-unit id="ScoreTeam2Full" translate="yes" xml:space="preserve">
           <source>ST2 (Score Team 2)</source>
-          <target state="new">ST2 (Score Team 2)</target>
+          <target state="needs-review">СК2 (Счёт Команды 2)</target>
         </trans-unit>
         <trans-unit id="ShowPlayerDemos" translate="yes" xml:space="preserve">
           <source>Show player demos</source>
-          <target state="new">Show player demos</target>
+          <target state="needs-review">Показать демки игрока</target>
         </trans-unit>
         <trans-unit id="ShowSuspectDemos" translate="yes" xml:space="preserve">
           <source>Show suspect demos</source>
-          <target state="new">Show suspect demos</target>
+          <target state="needs-review">Показать демки подозреваемого</target>
         </trans-unit>
         <trans-unit id="SideTroubleFull" translate="yes" xml:space="preserve">
           <source>ST (Side Trouble)</source>
-          <target state="new">ST (Side Trouble)</target>
+          <target state="needs-review">ПС (Проблемная Сторона)</target>
         </trans-unit>
         <trans-unit id="StartMoneyTeam1Full" translate="yes" xml:space="preserve">
           <source>SM CT (Start Money CT ($))</source>
-          <target state="new">SM CT (Start Money CT ($))</target>
+          <target state="needs-review">СД КТ (Стартовые Деньги КТ ($))</target>
         </trans-unit>
         <trans-unit id="StartMoneyTeam2Full" translate="yes" xml:space="preserve">
           <source>SM T (Start Money T ($))</source>
-          <target state="new">SM T (Start Money T ($))</target>
+          <target state="needs-review">СД Т (Стартовые Деньги Т ($))</target>
         </trans-unit>
         <trans-unit id="TeamNameTroubleFull" translate="yes" xml:space="preserve">
           <source>TNT (Team Name Trouble)</source>
-          <target state="new">TNT (Team Name Trouble)</target>
+          <target state="needs-review">ПК (Проблемная Команда)</target>
         </trans-unit>
         <trans-unit id="Tickrate" translate="yes" xml:space="preserve">
           <source>Tickrate</source>
-          <target state="new">Tickrate</target>
+          <target state="needs-review">Тикрейт</target>
         </trans-unit>
         <trans-unit id="TickrateFull" translate="yes" xml:space="preserve">
           <source>TR (Tickrate)</source>
-          <target state="new">TR (Tickrate)</target>
+          <target state="needs-review">ТР (Тикрейт)</target>
         </trans-unit>
         <trans-unit id="TotalDamagesArmorFull" translate="yes" xml:space="preserve">
           <source>TDA (Total Damages Armor)</source>
-          <target state="new">TDA (Total Damages Armor)</target>
+          <target state="needs-review">ВУБ (Всего Урона по Броне)</target>
         </trans-unit>
         <trans-unit id="TotalDamagesHealthFull" translate="yes" xml:space="preserve">
           <source>TDH (Total Damages Health)</source>
-          <target state="new">TDH (Total Damages Health)</target>
+          <target state="needs-review">ВУЗ (Всего Урона по Здоровью)</target>
         </trans-unit>
         <trans-unit id="TradeDeathsFull" translate="yes" xml:space="preserve">
           <source>TD (Trade Deaths)</source>
-          <target state="new">TD (Trade Deaths)</target>
+          <target state="needs-review">СР (Смертей в Размен)</target>
         </trans-unit>
         <trans-unit id="TradeKillsFull" translate="yes" xml:space="preserve">
           <source>TK (Trade Kills)</source>
-          <target state="new">TK (Trade Kills)</target>
+          <target state="needs-review">УР (Убийств в Размен)</target>
         </trans-unit>
         <trans-unit id="WatchPlayer" translate="yes" xml:space="preserve">
           <source>Watch player</source>
-          <target state="new">Watch player</target>
+          <target state="needs-review">Смотреть игрока</target>
         </trans-unit>
         <trans-unit id="WinnerSideFull" translate="yes" xml:space="preserve">
           <source>WS (Winner Side)</source>
-          <target state="new">WS (Winner Side)</target>
+          <target state="needs-review">ВС (Выиграла Сторона)</target>
         </trans-unit>
         <trans-unit id="WinnerTeamNameFull" translate="yes" xml:space="preserve">
           <source>WTN (Winner Team Name)</source>
-          <target state="new">WTN (Winner Team Name)</target>
+          <target state="needs-review">ВК (Выиграла Команда)</target>
         </trans-unit>
         <trans-unit id="Decoys" translate="yes" xml:space="preserve">
           <source>Decoys</source>
-          <target state="new">Decoys</target>
+          <target state="needs-review">Отвлекающие гранаты</target>
         </trans-unit>
         <trans-unit id="EndReasonBombDefused" translate="yes" xml:space="preserve">
           <source>Bomb defused</source>
-          <target state="new">Bomb defused</target>
+          <target state="needs-review">Бомб разминировано</target>
         </trans-unit>
         <trans-unit id="EndReasonBombExploded" translate="yes" xml:space="preserve">
           <source>Bomb exploded</source>
-          <target state="new">Bomb exploded</target>
+          <target state="needs-review">Бомб взорвано</target>
         </trans-unit>
         <trans-unit id="EndReasonCtSurrender" translate="yes" xml:space="preserve">
           <source>CT surrender</source>
-          <target state="new">CT surrender</target>
+          <target state="needs-review">КТ сдались</target>
         </trans-unit>
         <trans-unit id="EndReasonCtWin" translate="yes" xml:space="preserve">
           <source>Counter-Terrorists win</source>
-          <target state="new">Counter-Terrorists win</target>
+          <target state="needs-review">Контр-Террористы выиграли</target>
         </trans-unit>
         <trans-unit id="EndReasonTargetSaved" translate="yes" xml:space="preserve">
           <source>Time over</source>
-          <target state="new">Time over</target>
+          <target state="needs-review">Время вышло</target>
         </trans-unit>
         <trans-unit id="EndReasonTsurrender" translate="yes" xml:space="preserve">
           <source>T surrender</source>
-          <target state="new">T surrender</target>
+          <target state="needs-review">Т сдались</target>
         </trans-unit>
         <trans-unit id="EndReasonTwin" translate="yes" xml:space="preserve">
           <source>Terrorists win</source>
-          <target state="new">Terrorists win</target>
+          <target state="needs-review">Террористы выиграли</target>
         </trans-unit>
         <trans-unit id="EndReasonUnknown" translate="yes" xml:space="preserve">
           <source>Unknown</source>
-          <target state="new">Unknown</target>
+          <target state="needs-review">Неизвестно</target>
         </trans-unit>
         <trans-unit id="HeaderAssister" translate="yes" xml:space="preserve">
           <source>Assister</source>
-          <target state="new">Assister</target>
+          <target state="needs-review">Помощник</target>
         </trans-unit>
         <trans-unit id="HeaderEquipmentValuePlayer" translate="yes" xml:space="preserve">
           <source>EV ($)</source>
-          <target state="new">EV ($)</target>
+          <target state="needs-review">ЦЭ ($)</target>
         </trans-unit>
         <trans-unit id="HeaderHits" translate="yes" xml:space="preserve">
           <source>Hits</source>
-          <target state="new">Hits</target>
+          <target state="needs-review">Попаданий</target>
         </trans-unit>
         <trans-unit id="HeaderKiller" translate="yes" xml:space="preserve">
           <source>Killer</source>
-          <target state="new">Killer</target>
+          <target state="needs-review">Убийца</target>
         </trans-unit>
         <trans-unit id="HeaderShots" translate="yes" xml:space="preserve">
           <source>Shots</source>
-          <target state="new">Shots</target>
+          <target state="needs-review">Выстрелов</target>
         </trans-unit>
         <trans-unit id="HeaderStartMoneyPlayer" translate="yes" xml:space="preserve">
           <source>SM ($)</source>
-          <target state="new">SM ($)</target>
+          <target state="needs-review">СД ($)</target>
         </trans-unit>
         <trans-unit id="HeaderVictim" translate="yes" xml:space="preserve">
           <source>Victim</source>
-          <target state="new">Victim</target>
+          <target state="needs-review">Жертва</target>
         </trans-unit>
         <trans-unit id="HeaderWeapon" translate="yes" xml:space="preserve">
           <source>Weapon</source>
-          <target state="new">Weapon</target>
+          <target state="needs-review">Оружие</target>
         </trans-unit>
         <trans-unit id="HeGrenades" translate="yes" xml:space="preserve">
           <source>HE Grenades</source>
-          <target state="new">HE Grenades</target>
+          <target state="needs-review">Боевые гранаты</target>
         </trans-unit>
         <trans-unit id="Incendiaries" translate="yes" xml:space="preserve">
           <source>Incendiaries</source>
-          <target state="new">Incendiaries</target>
+          <target state="needs-review">Зажигательные</target>
         </trans-unit>
         <trans-unit id="LabelWinnerSide" translate="yes" xml:space="preserve">
           <source>Winner side</source>
-          <target state="new">Winner side</target>
+          <target state="needs-review">Выиграла сторона</target>
         </trans-unit>
         <trans-unit id="Molotovs" translate="yes" xml:space="preserve">
           <source>Molotovs</source>
-          <target state="new">Molotovs</target>
+          <target state="needs-review">Коктейли Иолотова</target>
         </trans-unit>
         <trans-unit id="Players" translate="yes" xml:space="preserve">
           <source>Players</source>
-          <target state="new">Players</target>
+          <target state="needs-review">Игроки</target>
         </trans-unit>
         <trans-unit id="Reason" translate="yes" xml:space="preserve">
           <source>Reason</source>
-          <target state="new">Reason</target>
+          <target state="needs-review">Причина</target>
         </trans-unit>
         <trans-unit id="Smoke" translate="yes" xml:space="preserve">
           <source>Smoke</source>
-          <target state="new">Smoke</target>
+          <target state="needs-review">Дымовые гранаты</target>
         </trans-unit>
         <trans-unit id="StartMoney" translate="yes" xml:space="preserve">
           <source>Start money</source>
-          <target state="new">Start money</target>
+          <target state="needs-review">Стартовые деньги</target>
         </trans-unit>
         <trans-unit id="Timeline" translate="yes" xml:space="preserve">
           <source>Timeline</source>
-          <target state="new">Timeline</target>
+          <target state="needs-review">Временная шкала</target>
         </trans-unit>
         <trans-unit id="ToolTipNextRound" translate="yes" xml:space="preserve">
           <source>Next round</source>
-          <target state="new">Next round</target>
+          <target state="needs-review">Следующий раунд</target>
         </trans-unit>
         <trans-unit id="ToolTipPreviousRound" translate="yes" xml:space="preserve">
           <source>Previous round</source>
-          <target state="new">Previous round</target>
+          <target state="needs-review">Предыдущий раунд</target>
         </trans-unit>
         <trans-unit id="Unknown" translate="yes" xml:space="preserve">
           <source>Unknown</source>
-          <target state="new">Unknown</target>
+          <target state="needs-review">Неизвестно</target>
         </trans-unit>
         <trans-unit id="ArmorDamages" translate="yes" xml:space="preserve">
           <source>Armor damages</source>
-          <target state="new">Armor damages</target>
+          <target state="needs-review">Урона по броне</target>
         </trans-unit>
         <trans-unit id="Attempts" translate="yes" xml:space="preserve">
           <source>Attempts</source>
-          <target state="new">Attempts</target>
+          <target state="needs-review">Попыток</target>
         </trans-unit>
         <trans-unit id="ClutchesLoss" translate="yes" xml:space="preserve">
           <source>Clutches loss</source>
-          <target state="new">Clutches loss</target>
+          <target state="needs-review">Клатчей проиграно</target>
         </trans-unit>
         <trans-unit id="ClutchesWon" translate="yes" xml:space="preserve">
           <source>Clutches won</source>
-          <target state="new">Clutches won</target>
+          <target state="needs-review">Клатчей выиграно</target>
         </trans-unit>
         <trans-unit id="ClutchesWonPercent" translate="yes" xml:space="preserve">
           <source>Clutches won %</source>
-          <target state="new">Clutches won %</target>
+          <target state="needs-review">Клатчей выиграно %</target>
         </trans-unit>
         <trans-unit id="DamagesPerRound" translate="yes" xml:space="preserve">
           <source>Damages per round</source>
-          <target state="new">Damages per round</target>
+          <target state="needs-review">Урона за раунд</target>
         </trans-unit>
         <trans-unit id="EntryHoldKills" translate="yes" xml:space="preserve">
           <source>Entry hold kills</source>
-          <target state="new">Entry hold kills</target>
+          <target state="needs-review">Оборонительных убийств</target>
         </trans-unit>
         <trans-unit id="EntryHoldKillsDescription" translate="yes" xml:space="preserve">
           <source>(First kill as CT)</source>
-          <target state="new">(First kill as CT)</target>
+          <target state="needs-review">(Первое убийство за КТ)</target>
         </trans-unit>
         <trans-unit id="EntryKillDescription" translate="yes" xml:space="preserve">
           <source>(First kill as T)</source>
-          <target state="new">(First kill as T)</target>
+          <target state="needs-review">(Первое убийство за Т)</target>
         </trans-unit>
         <trans-unit id="EquipmentValue" translate="yes" xml:space="preserve">
           <source>Equipment value ($)</source>
-          <target state="new">Equipment value ($)</target>
+          <target state="needs-review">Цена экипировки ($)</target>
         </trans-unit>
         <trans-unit id="EquipmentValuePerRound" translate="yes" xml:space="preserve">
           <source>Equipment value per round ($)</source>
-          <target state="new">Equipment value per round ($)</target>
+          <target state="needs-review">Цена экипировки за раунд ($)</target>
         </trans-unit>
         <trans-unit id="HeaderKillerSide" translate="yes" xml:space="preserve">
           <source>KS</source>
-          <target state="new">KS</target>
+          <target state="needs-review">СУ</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Killer Side</note>
         </trans-unit>
         <trans-unit id="HeaderRound" translate="yes" xml:space="preserve">
           <source>Round</source>
-          <target state="new">Round</target>
+          <target state="needs-review">Раундов</target>
         </trans-unit>
         <trans-unit id="HeaderRoundWon" translate="yes" xml:space="preserve">
           <source>RW</source>
-          <target state="new">RW</target>
+          <target state="needs-review">РВ</target>
         </trans-unit>
         <trans-unit id="HeaderWon" translate="yes" xml:space="preserve">
           <source>Won</source>
-          <target state="new">Won</target>
+          <target state="needs-review">Выиграно</target>
         </trans-unit>
         <trans-unit id="HealthDamages" translate="yes" xml:space="preserve">
           <source>Health damages</source>
-          <target state="new">Health damages</target>
+          <target state="needs-review">Урона по Здоровью</target>
         </trans-unit>
         <trans-unit id="Loss" translate="yes" xml:space="preserve">
           <source>Loss</source>
-          <target state="new">Loss</target>
+          <target state="needs-review">Проиграно</target>
         </trans-unit>
         <trans-unit id="No" translate="yes" xml:space="preserve">
           <source>No</source>
-          <target state="new">No</target>
+          <target state="needs-review">Нет</target>
         </trans-unit>
         <trans-unit id="OneVersusFiveLoss" translate="yes" xml:space="preserve">
           <source>1V5 loss</source>
-          <target state="new">1V5 loss</target>
+          <target state="needs-review">1в5 проиграно</target>
         </trans-unit>
         <trans-unit id="OneVersusFiveWon" translate="yes" xml:space="preserve">
           <source>1V5 won</source>
-          <target state="new">1V5 won</target>
+          <target state="needs-review">1в5 выиграно</target>
         </trans-unit>
         <trans-unit id="OneVersusFiveWonPercent" translate="yes" xml:space="preserve">
           <source>1V5 won %</source>
-          <target state="new">1V5 won %</target>
+          <target state="needs-review">1в5 выиграно %</target>
         </trans-unit>
         <trans-unit id="OneVersusFourLoss" translate="yes" xml:space="preserve">
           <source>1V4 loss</source>
-          <target state="new">1V4 loss</target>
+          <target state="needs-review">1в4 проиграно</target>
         </trans-unit>
         <trans-unit id="OneVersusFourWon" translate="yes" xml:space="preserve">
           <source>1V4 won</source>
-          <target state="new">1V4 won</target>
+          <target state="needs-review">1в4 выиграно</target>
         </trans-unit>
         <trans-unit id="OneVersusFourWonPercent" translate="yes" xml:space="preserve">
           <source>1V4 won %</source>
-          <target state="new">1V4 won %</target>
+          <target state="needs-review">1в4 выиграно %</target>
         </trans-unit>
         <trans-unit id="OneVersusOneLoss" translate="yes" xml:space="preserve">
           <source>1V1 loss</source>
-          <target state="new">1V1 loss</target>
+          <target state="needs-review">1в1 проиграно</target>
         </trans-unit>
         <trans-unit id="OneVersusOneWon" translate="yes" xml:space="preserve">
           <source>1V1 won</source>
-          <target state="new">1V1 won</target>
+          <target state="needs-review">1в1 выиграно</target>
         </trans-unit>
         <trans-unit id="OneVersusOneWonPercent" translate="yes" xml:space="preserve">
           <source>1V1 won %</source>
-          <target state="new">1V1 won %</target>
+          <target state="needs-review">1в1 выиграно %</target>
         </trans-unit>
         <trans-unit id="OneVersusThreeLoss" translate="yes" xml:space="preserve">
           <source>1V3 loss</source>
-          <target state="new">1V3 loss</target>
+          <target state="needs-review">1в3 проиграно</target>
         </trans-unit>
         <trans-unit id="OneVersusThreeWon" translate="yes" xml:space="preserve">
           <source>1V3 won</source>
-          <target state="new">1V3 won</target>
+          <target state="needs-review">1в3 выиграно</target>
         </trans-unit>
         <trans-unit id="OneVersusThreeWonPercent" translate="yes" xml:space="preserve">
           <source>1V3 won %</source>
-          <target state="new">1V3 won %</target>
+          <target state="needs-review">1в3 выиграно %</target>
         </trans-unit>
         <trans-unit id="OneVersusTwoLoss" translate="yes" xml:space="preserve">
           <source>1V2 loss</source>
-          <target state="new">1V2 loss</target>
+          <target state="needs-review">1в2 проиграно</target>
         </trans-unit>
         <trans-unit id="OneVersusTwoWon" translate="yes" xml:space="preserve">
           <source>1V2 won</source>
-          <target state="new">1V2 won</target>
+          <target state="needs-review">1в2 выиграно</target>
         </trans-unit>
         <trans-unit id="OneVersusTwoWonPercent" translate="yes" xml:space="preserve">
           <source>1V2 won %</source>
-          <target state="new">1V2 won %</target>
+          <target state="needs-review">1в2 выиграно %</target>
         </trans-unit>
         <trans-unit id="Round" translate="yes" xml:space="preserve">
           <source>Round</source>
-          <target state="new">Round</target>
+          <target state="needs-review">Раундов</target>
         </trans-unit>
         <trans-unit id="RoundTypeEco" translate="yes" xml:space="preserve">
           <source>Eco</source>
-          <target state="new">Eco</target>
+          <target state="needs-review">Эко</target>
         </trans-unit>
         <trans-unit id="RoundTypeForceBuy" translate="yes" xml:space="preserve">
           <source>Force buy</source>
-          <target state="new">Force buy</target>
+          <target state="needs-review">Форсбай</target>
         </trans-unit>
         <trans-unit id="RoundTypeNormal" translate="yes" xml:space="preserve">
           <source>Normal</source>
-          <target state="new">Normal</target>
+          <target state="needs-review">Норм</target>
         </trans-unit>
         <trans-unit id="RoundTypePistolRound" translate="yes" xml:space="preserve">
           <source>Pistol round</source>
-          <target state="new">Pistol round</target>
+          <target state="needs-review">Пистолетный</target>
         </trans-unit>
         <trans-unit id="RoundTypeSemiEco" translate="yes" xml:space="preserve">
           <source>Semi-Eco</source>
-          <target state="new">Semi-Eco</target>
+          <target state="needs-review">Полу-эко</target>
         </trans-unit>
         <trans-unit id="Total" translate="yes" xml:space="preserve">
           <source>Total</source>
-          <target state="new">Total</target>
+          <target state="needs-review">Всего</target>
         </trans-unit>
         <trans-unit id="TotalArmorDamages" translate="yes" xml:space="preserve">
           <source>Total armor damages</source>
-          <target state="new">Total armor damages</target>
+          <target state="needs-review">Всего урона по броне</target>
         </trans-unit>
         <trans-unit id="TotalClutches" translate="yes" xml:space="preserve">
           <source>Total clutches</source>
-          <target state="new">Total clutches</target>
+          <target state="needs-review">Всего клатчей</target>
         </trans-unit>
         <trans-unit id="TotalClutchesLoss" translate="yes" xml:space="preserve">
           <source>Total clutches loss</source>
-          <target state="new">Total clutches loss</target>
+          <target state="needs-review">Всего клатчей проиграно</target>
         </trans-unit>
         <trans-unit id="TotalClutchesWon" translate="yes" xml:space="preserve">
           <source>Total clutches won</source>
-          <target state="new">Total clutches won</target>
+          <target state="needs-review">Всего клатчей выиграно</target>
         </trans-unit>
         <trans-unit id="TotalDamages" translate="yes" xml:space="preserve">
           <source>Total damages</source>
-          <target state="new">Total damages</target>
+          <target state="needs-review">Всего урона</target>
         </trans-unit>
         <trans-unit id="TotalHealthDamages" translate="yes" xml:space="preserve">
           <source>Total health damages</source>
-          <target state="new">Total health damages</target>
+          <target state="needs-review">Всего Урона по Здоровью</target>
         </trans-unit>
         <trans-unit id="TotalOneVersusFiveLoss" translate="yes" xml:space="preserve">
           <source>Total 1V5 loss</source>
-          <target state="new">Total 1V5 loss</target>
+          <target state="needs-review">Всего 1в5 проиграно</target>
         </trans-unit>
         <trans-unit id="TotalOneVersusFiveWon" translate="yes" xml:space="preserve">
           <source>Total 1V5 won</source>
-          <target state="new">Total 1V5 won</target>
+          <target state="needs-review">Всего 1в5 выиграно</target>
         </trans-unit>
         <trans-unit id="TotalOneVersusFourLoss" translate="yes" xml:space="preserve">
           <source>Total 1V4 loss</source>
-          <target state="new">Total 1V4 loss</target>
+          <target state="needs-review">Всего 1в4 проиграно</target>
         </trans-unit>
         <trans-unit id="TotalOneVersusFourWon" translate="yes" xml:space="preserve">
           <source>Total 1V4 won</source>
-          <target state="new">Total 1V4 won</target>
+          <target state="needs-review">Всего 1в4 выиграно</target>
         </trans-unit>
         <trans-unit id="TotalOneVersusOneLoss" translate="yes" xml:space="preserve">
           <source>Total 1V1 loss</source>
-          <target state="new">Total 1V1 loss</target>
+          <target state="needs-review">Всего 1в1 проиграно</target>
         </trans-unit>
         <trans-unit id="TotalOneVersusOneWon" translate="yes" xml:space="preserve">
           <source>Total 1V1 won</source>
-          <target state="new">Total 1V1 won</target>
+          <target state="needs-review">Всего 1в1 выиграно</target>
         </trans-unit>
         <trans-unit id="TotalOneVersusThreeLoss" translate="yes" xml:space="preserve">
           <source>Total 1V3 loss</source>
-          <target state="new">Total 1V3 loss</target>
+          <target state="needs-review">Всего 1в3 проиграно</target>
         </trans-unit>
         <trans-unit id="TotalOneVersusThreeWon" translate="yes" xml:space="preserve">
           <source>Total 1V3 won</source>
-          <target state="new">Total 1V3 won</target>
+          <target state="needs-review">Всего 1в3 выиграно</target>
         </trans-unit>
         <trans-unit id="TotalOneVersusTwoLoss" translate="yes" xml:space="preserve">
           <source>Total 1V2 loss</source>
-          <target state="new">Total 1V2 loss</target>
+          <target state="needs-review">Всего 1в2 проиграно</target>
         </trans-unit>
         <trans-unit id="TotalOneVersusTwoWon" translate="yes" xml:space="preserve">
           <source>Total 1V2 won</source>
-          <target state="new">Total 1V2 won</target>
+          <target state="needs-review">Всего 1в2 выиграно</target>
         </trans-unit>
         <trans-unit id="TradeKillsDeaths" translate="yes" xml:space="preserve">
           <source>Trade kills / deaths</source>
-          <target state="new">Trade kills / deaths</target>
+          <target state="needs-review">Убийств в размен / смертей</target>
         </trans-unit>
         <trans-unit id="TradeKillsDeathsDescription" translate="yes" xml:space="preserve">
           <source>(Kill revenge occured maximum 4s after the initial kill)</source>
-          <target state="new">(Kill revenge occured maximum 4s after the initial kill)</target>
+          <target state="needs-review">(Месть произошла в течение 4c после инициирующего убийства)</target>
         </trans-unit>
         <trans-unit id="Value" translate="yes" xml:space="preserve">
           <source>Value</source>
-          <target state="new">Value</target>
+          <target state="needs-review">Цена</target>
         </trans-unit>
         <trans-unit id="Won" translate="yes" xml:space="preserve">
           <source>Won</source>
-          <target state="new">Won</target>
+          <target state="needs-review">Выиграно</target>
         </trans-unit>
         <trans-unit id="WonRate" translate="yes" xml:space="preserve">
           <source>Won rate</source>
-          <target state="new">Won rate</target>
+          <target state="needs-review">Процент побед</target>
         </trans-unit>
         <trans-unit id="HeaderOneVersusX" translate="yes" xml:space="preserve">
           <source>1VX</source>
-          <target state="new">1VX</target>
+          <target state="needs-review">1вХ</target>
         </trans-unit>
         <trans-unit id="Headshots" translate="yes" xml:space="preserve">
           <source>Headshots</source>
-          <target state="new">Headshots</target>
+          <target state="needs-review">Убийств в голову</target>
         </trans-unit>
         <trans-unit id="HeaderHeadshotsPercent" translate="yes" xml:space="preserve">
           <source>HS %</source>
-          <target state="new">HS %</target>
+          <target state="needs-review">УГ %</target>
         </trans-unit>
         <trans-unit id="AverageValue" translate="yes" xml:space="preserve">
           <source>Average value</source>
-          <target state="new">Average value</target>
+          <target state="needs-review">Средняя </target>
         </trans-unit>
         <trans-unit id="CrouchKillPercent" translate="yes" xml:space="preserve">
           <source>Crouch kill %</source>
-          <target state="new">Crouch kill %</target>
+          <target state="needs-review">Убийств сидя %</target>
         </trans-unit>
         <trans-unit id="CrouchKillPercentPerMatch" translate="yes" xml:space="preserve">
           <source>Crouch kill % per match</source>
-          <target state="new">Crouch kill % per match</target>
+          <target state="needs-review">Убийств сидя % за матч</target>
         </trans-unit>
         <trans-unit id="DamagePerGameValue" translate="yes" xml:space="preserve">
           <source>Damage per game value</source>
-          <target state="new">Damage per game value</target>
+          <target state="needs-review">Урон за цену в игре</target>
         </trans-unit>
         <trans-unit id="Death" translate="yes" xml:space="preserve">
           <source>Death</source>
-          <target state="new">Death</target>
+          <target state="needs-review">Смертей</target>
         </trans-unit>
         <trans-unit id="DeathAverage" translate="yes" xml:space="preserve">
           <source>Death average</source>
-          <target state="new">Death average</target>
+          <target state="needs-review">Смертей в среднем</target>
         </trans-unit>
         <trans-unit id="Draw" translate="yes" xml:space="preserve">
           <source>Draw</source>
-          <target state="new">Draw</target>
+          <target state="needs-review">Ничья</target>
         </trans-unit>
         <trans-unit id="Duels" translate="yes" xml:space="preserve">
           <source>Duels</source>
-          <target state="new">Duels</target>
+          <target state="needs-review">Дуэли</target>
         </trans-unit>
         <trans-unit id="Economy" translate="yes" xml:space="preserve">
           <source>Economy</source>
-          <target state="new">Economy</target>
+          <target state="needs-review">Экономика</target>
         </trans-unit>
         <trans-unit id="General" translate="yes" xml:space="preserve">
           <source>General</source>
-          <target state="new">General</target>
+          <target state="needs-review">Общее</target>
         </trans-unit>
         <trans-unit id="HeadshotPercentPerMatch" translate="yes" xml:space="preserve">
           <source>Headshot % per match</source>
-          <target state="new">Headshot % per match</target>
+          <target state="needs-review">Убийств в голову % за матч</target>
         </trans-unit>
         <trans-unit id="Heavy" translate="yes" xml:space="preserve">
           <source>Heavy</source>
-          <target state="new">Heavy</target>
+          <target state="needs-review">Тяжёлое</target>
         </trans-unit>
         <trans-unit id="Kill" translate="yes" xml:space="preserve">
           <source>Kill</source>
-          <target state="new">Kill</target>
+          <target state="needs-review">Убийств</target>
         </trans-unit>
         <trans-unit id="KillAverage" translate="yes" xml:space="preserve">
           <source>Kill average</source>
-          <target state="new">Kill average</target>
+          <target state="needs-review">Убийств в среднем</target>
         </trans-unit>
         <trans-unit id="KillVelocity" translate="yes" xml:space="preserve">
           <source>Kill velocity</source>
-          <target state="new">Kill velocity</target>
+          <target state="needs-review">Скорость убийства</target>
         </trans-unit>
         <trans-unit id="HeaderKnifeKills" translate="yes" xml:space="preserve">
           <source>KK</source>
-          <target state="new">KK</target>
+          <target state="needs-review">УН</target>
         </trans-unit>
         <trans-unit id="Maps" translate="yes" xml:space="preserve">
           <source>Maps</source>
-          <target state="new">Maps</target>
+          <target state="needs-review">Карт</target>
         </trans-unit>
         <trans-unit id="Matches" translate="yes" xml:space="preserve">
           <source>Matches</source>
-          <target state="new">Matches</target>
+          <target state="needs-review">Матчей</target>
         </trans-unit>
         <trans-unit id="MatchesStats" translate="yes" xml:space="preserve">
           <source>Matches stats</source>
-          <target state="new">Matches stats</target>
+          <target state="needs-review">Статистика матчей</target>
         </trans-unit>
         <trans-unit id="Overall" translate="yes" xml:space="preserve">
           <source>Overall</source>
-          <target state="new">Overall</target>
+          <target state="needs-review">Обзор</target>
         </trans-unit>
         <trans-unit id="Percentage" translate="yes" xml:space="preserve">
           <source>Percentage</source>
-          <target state="new">Percentage</target>
+          <target state="needs-review">Процент</target>
         </trans-unit>
         <trans-unit id="Pistol" translate="yes" xml:space="preserve">
           <source>Pistol</source>
-          <target state="new">Pistol</target>
+          <target state="needs-review">Пистолет</target>
         </trans-unit>
         <trans-unit id="Pistoles" translate="yes" xml:space="preserve">
           <source>Pistols</source>
-          <target state="new">Pistols</target>
+          <target state="needs-review">Пистолеты</target>
         </trans-unit>
         <trans-unit id="Progression" translate="yes" xml:space="preserve">
           <source>Progression</source>
-          <target state="new">Progression</target>
+          <target state="needs-review">Прогресс</target>
         </trans-unit>
         <trans-unit id="Rifle" translate="yes" xml:space="preserve">
           <source>Rifle</source>
-          <target state="new">Rifle</target>
+          <target state="needs-review">Ружьё</target>
         </trans-unit>
         <trans-unit id="Rifles" translate="yes" xml:space="preserve">
           <source>Rifles</source>
-          <target state="new">Rifles</target>
+          <target state="needs-review">Ружья</target>
         </trans-unit>
         <trans-unit id="Rounds" translate="yes" xml:space="preserve">
           <source>Rounds</source>
-          <target state="new">Rounds</target>
+          <target state="needs-review">Раундов</target>
         </trans-unit>
         <trans-unit id="Smg" translate="yes" xml:space="preserve">
           <source>SMG</source>
-          <target state="new">SMG</target>
+          <target state="needs-review">Полуавтомат</target>
         </trans-unit>
         <trans-unit id="Smgs" translate="yes" xml:space="preserve">
           <source>SMGs</source>
-          <target state="new">SMGs</target>
+          <target state="needs-review">Полуавтоматы</target>
         </trans-unit>
         <trans-unit id="Sniper" translate="yes" xml:space="preserve">
           <source>Sniper</source>
-          <target state="new">Sniper</target>
+          <target state="needs-review">Снайпер</target>
         </trans-unit>
         <trans-unit id="Snipers" translate="yes" xml:space="preserve">
           <source>Snipers</source>
-          <target state="new">Snipers</target>
+          <target state="needs-review">Снайперы</target>
         </trans-unit>
         <trans-unit id="TipsGraphAverageKillVelocity" translate="yes" xml:space="preserve">
           <source>This graph displays your average velocity when you killed someone by weapon group</source>
-          <target state="new">This graph displays your average velocity when you killed someone by weapon group</target>
+          <target state="needs-review">Этот график отображает вашу среднюю скорость, когда вы убили кого-то из оружия этой группы</target>
         </trans-unit>
         <trans-unit id="TipsMaximumVelocity" translate="yes" xml:space="preserve">
           <source>Information : The maximum velocity while running is 250 unit/s</source>
-          <target state="new">Information : The maximum velocity while running is 250 unit/s</target>
+          <target state="needs-review">Информация : Максимальная скорость во время бега 250 ед/с</target>
         </trans-unit>
         <trans-unit id="ToolTipAddPlayerToSuspectsList" translate="yes" xml:space="preserve">
           <source>Add player to suspects list (CTRL+S)</source>
-          <target state="new">Add player to suspects list (CTRL+S)</target>
+          <target state="needs-review">Добавить игрока в лист подозреваемых (CTRL+S)</target>
         </trans-unit>
         <trans-unit id="ToolTipAddPlayerToWhiteList" translate="yes" xml:space="preserve">
           <source>Add player to whitelist (CTRL+W)</source>
-          <target state="new">Add player to whitelist (CTRL+W)</target>
+          <target state="needs-review">Добавить игрока в белый список (CTRL+W)</target>
         </trans-unit>
         <trans-unit id="ToolTipMaps" translate="yes" xml:space="preserve">
           <source>Maps (CTRL+M)</source>
-          <target state="new">Maps (CTRL+M)</target>
+          <target state="needs-review">Карты (CTRL+M)</target>
         </trans-unit>
         <trans-unit id="ToolTipMatchesPlayed" translate="yes" xml:space="preserve">
           <source>Matches played</source>
-          <target state="new">Matches played</target>
+          <target state="needs-review">Матчей сыграно</target>
         </trans-unit>
         <trans-unit id="ToolTipOverall" translate="yes" xml:space="preserve">
           <source>Overall (CTRL+O)</source>
-          <target state="new">Overall (CTRL+O)</target>
+          <target state="needs-review">Обзор (CTRL+O)</target>
         </trans-unit>
         <trans-unit id="ToolTipProgression" translate="yes" xml:space="preserve">
           <source>Progression (CTRL+P)</source>
-          <target state="new">Progression (CTRL+P)</target>
+          <target state="needs-review">Прогресс (CTRL+P)</target>
         </trans-unit>
         <trans-unit id="ToolTipRank" translate="yes" xml:space="preserve">
           <source>Rank (CTRL+R)</source>
-          <target state="new">Rank (CTRL+R)</target>
+          <target state="needs-review">Ранг (CTRL+R)</target>
         </trans-unit>
         <trans-unit id="ToolTipTotalAssists" translate="yes" xml:space="preserve">
           <source>Total assists</source>
-          <target state="new">Total assists</target>
+          <target state="needs-review">Всего помощей</target>
         </trans-unit>
         <trans-unit id="ToolTipTotalBombDefused" translate="yes" xml:space="preserve">
           <source>Total bomb defused</source>
-          <target state="new">Total bomb defused</target>
+          <target state="needs-review">Всего бомб разминировано</target>
         </trans-unit>
         <trans-unit id="ToolTipTotalBombExploded" translate="yes" xml:space="preserve">
           <source>Total bomb exploded</source>
-          <target state="new">Total bomb exploded</target>
+          <target state="needs-review">Всего бомб взорвано</target>
         </trans-unit>
         <trans-unit id="ToolTipTotalBombPlanted" translate="yes" xml:space="preserve">
           <source>Total bomb planted</source>
-          <target state="new">Total bomb planted</target>
+          <target state="needs-review">Всего бомб установлено</target>
         </trans-unit>
         <trans-unit id="ToolTipTotalDamages" translate="yes" xml:space="preserve">
           <source>Total damages</source>
-          <target state="new">Total damages</target>
+          <target state="needs-review">Всего урона</target>
         </trans-unit>
         <trans-unit id="ToolTipTotalDeaths" translate="yes" xml:space="preserve">
           <source>Total deaths</source>
-          <target state="new">Total deaths</target>
+          <target state="needs-review">Всего смертей</target>
         </trans-unit>
         <trans-unit id="ToolTipTotalHeadshots" translate="yes" xml:space="preserve">
           <source>Total headshots</source>
-          <target state="new">Total headshots</target>
+          <target state="needs-review">Всего убийств в голову</target>
         </trans-unit>
         <trans-unit id="ToolTipTotalMvp" translate="yes" xml:space="preserve">
           <source>Total MVP</source>
-          <target state="new">Total MVP</target>
+          <target state="needs-review">Всего СЦИ</target>
         </trans-unit>
         <trans-unit id="ToolTipTotalRoundPlayed" translate="yes" xml:space="preserve">
           <source>Total rounds played</source>
-          <target state="new">Total rounds played</target>
+          <target state="needs-review">Всего раундов сыграно</target>
         </trans-unit>
         <trans-unit id="ToolTipWeapons" translate="yes" xml:space="preserve">
           <source>Weapons (CTRL+W)</source>
-          <target state="new">Weapons (CTRL+W)</target>
+          <target state="needs-review">Оружие (CTRL+W)</target>
         </trans-unit>
         <trans-unit id="VelocityAverage" translate="yes" xml:space="preserve">
           <source>Velocity average</source>
-          <target state="new">Velocity average</target>
+          <target state="needs-review">Средняя скорость</target>
         </trans-unit>
         <trans-unit id="WeaponKills" translate="yes" xml:space="preserve">
           <source>Weapon Kills</source>
-          <target state="new">Weapon Kills</target>
+          <target state="needs-review">Убийств Оружием</target>
         </trans-unit>
         <trans-unit id="Weapons" translate="yes" xml:space="preserve">
           <source>Weapons</source>
-          <target state="new">Weapons</target>
+          <target state="needs-review">Оружие</target>
         </trans-unit>
         <trans-unit id="WeeklyPercent" translate="yes" xml:space="preserve">
           <source>Weekly %</source>
-          <target state="new">Weekly %</target>
+          <target state="needs-review">Недельный %</target>
         </trans-unit>
         <trans-unit id="Win" translate="yes" xml:space="preserve">
           <source>Win</source>
-          <target state="new">Win</target>
+          <target state="needs-review">Побед</target>
         </trans-unit>
         <trans-unit id="WinPercent" translate="yes" xml:space="preserve">
           <source>Win percentage</source>
-          <target state="new">Win percentage</target>
+          <target state="needs-review">Процент побед</target>
         </trans-unit>
         <trans-unit id="Cancel" translate="yes" xml:space="preserve">
           <source>Cancel</source>
-          <target state="new">Cancel</target>
+          <target state="needs-review">Отмена</target>
         </trans-unit>
         <trans-unit id="CompetitivesWins" translate="yes" xml:space="preserve">
           <source>competitives wins</source>
-          <target state="new">competitives wins</target>
+          <target state="needs-review">соревновательных побед</target>
         </trans-unit>
         <trans-unit id="Demo" translate="yes" xml:space="preserve">
           <source>Demo</source>
-          <target state="new">Demo</target>
+          <target state="needs-review">Демка</target>
         </trans-unit>
         <trans-unit id="DialogDemoNotFound" translate="yes" xml:space="preserve">
           <source>Demo not found.</source>
-          <target state="new">Demo not found.</target>
+          <target state="needs-review">Демка не найдена.</target>
         </trans-unit>
         <trans-unit id="DialogDemosHaveBeenDownloaded" translate="yes" xml:space="preserve">
           <source>{0} demo(s) have been downloaded.</source>
-          <target state="new">{0} demo(s) have been downloaded.</target>
+          <target state="needs-review">{0} демок было загружено.</target>
         </trans-unit>
         <trans-unit id="DialogDemosRemovedFromCache" translate="yes" xml:space="preserve">
           <source>{0} demo(s) deleted from data cache.</source>
-          <target state="new">{0} demo(s) deleted from data cache.</target>
+          <target state="needs-review">{0} демок удалено из кэша.</target>
         </trans-unit>
         <trans-unit id="DialogDemosSentToRecycleBin" translate="yes" xml:space="preserve">
           <source>{0} demo(s) sent to Recycle Bin.</source>
-          <target state="new">{0} demo(s) sent to Recycle Bin.</target>
+          <target state="needs-review">{0} демок отправлено в Корзину.</target>
         </trans-unit>
         <trans-unit id="DialogEnterTick" translate="yes" xml:space="preserve">
           <source>Enter the tick.</source>
-          <target state="new">Enter the tick.</target>
+          <target state="needs-review">Введите тик.</target>
         </trans-unit>
         <trans-unit id="DialogErrorAnalyzingDemos" translate="yes" xml:space="preserve">
           <source>An error occurred while analyzing the demos.
@@ -2245,313 +2245,313 @@ Please create an issue on GitHub with the affected demos only if it comes from a
 You can find more information on {0}.
 
 {1}</source>
-          <target state="new">An error occurred while analyzing the demos.
-- Make sure the demos source is correct.
-- POV demos are not supported.
-- Demos coming from a custom server are not officially supported and thus may not work properly, you can try to change the demo's source and re-analyze it.
+          <target state="needs-review">Произошла ошибка при анализе демок.
+- Убедитесь, что источник демок указан верно.
+- POV демки не поддерживаются.
+- Демки, взятые с пользовательского сервера, официально не поддерживаются и поэтому могут работать некорректно, вы можете попробовать изменить источник демки и повторно проанализировать её.
 
-Please create an issue on GitHub with the affected demos only if it comes from a supported source.
-You can find more information on {0}.
+Пожалуйста создавайте заявку на GitHub с упомянутыми демками, только если они получены из поддерживаемого источника. 
+Дополнительную информацию вы можете найти на {0}.
 
 {1}</target>
         </trans-unit>
         <trans-unit id="DialogErrorGettingSuspectsData" translate="yes" xml:space="preserve">
           <source>Error while trying to get suspects information.</source>
-          <target state="new">Error while trying to get suspects information.</target>
+          <target state="needs-review">Ошибка при получении информации о подозреваемых.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileExportingDemo" translate="yes" xml:space="preserve">
           <source>An error occured while exporting the demo.</source>
-          <target state="new">An error occured while exporting the demo.</target>
+          <target state="needs-review">Возникла ошибка при экспорте демки.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileExportingDemos" translate="yes" xml:space="preserve">
           <source>An error occured while exporting demos.</source>
-          <target state="new">An error occured while exporting demos.</target>
+          <target state="needs-review">Возникла ошибка при экспорте демок.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileRefreshingLastRank" translate="yes" xml:space="preserve">
           <source>An error occured while refreshing last rank.</source>
-          <target state="new">An error occured while refreshing last rank.</target>
+          <target state="needs-review">Возникла ошибка при обновлении последнего ранга.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileRetrievingMatchesData" translate="yes" xml:space="preserve">
           <source>An error occured while retrieving matches information.</source>
-          <target state="new">An error occured while retrieving matches information.</target>
+          <target state="needs-review">Возникла ошибка при получении информации о матчах.</target>
         </trans-unit>
         <trans-unit id="DialogExportMultipleOrSingle" translate="yes" xml:space="preserve">
           <source>Do you want to export data into a single file or in multiple files?</source>
-          <target state="new">Do you want to export data into a single file or in multiple files?</target>
+          <target state="needs-review">Хотите экспортировать данные в один файл или в множество отдельных файлов?</target>
         </trans-unit>
         <trans-unit id="DialogExportPlayer" translate="yes" xml:space="preserve">
           <source>You are going to export data for the player "{0}".
 Do you want to continue?</source>
-          <target state="new">You are going to export data for the player "{0}".
-Do you want to continue?</target>
+          <target state="needs-review">Вы собираетесь экспортировать данные для игрока "{0}".
+Хотите продолжить?</target>
         </trans-unit>
         <trans-unit id="DialogGoToTick" translate="yes" xml:space="preserve">
           <source>Goto Tick</source>
-          <target state="new">Goto Tick</target>
+          <target state="needs-review">Задать Тик</target>
         </trans-unit>
         <trans-unit id="DialogInvalidTick" translate="yes" xml:space="preserve">
           <source>Invalid tick.</source>
-          <target state="new">Invalid tick.</target>
+          <target state="needs-review">Неверный тик.</target>
         </trans-unit>
         <trans-unit id="DialogNoNewerDemo" translate="yes" xml:space="preserve">
           <source>No newer demo available.</source>
-          <target state="new">No newer demo available.</target>
+          <target state="needs-review">Нет свежих демок.</target>
         </trans-unit>
         <trans-unit id="DialogRemoveDemosFromCacheConfirmation" translate="yes" xml:space="preserve">
           <source>Are you sure you want to delete this demo(s) from data cache?
 This will not delete this demo(s) from your HDD.</source>
-          <target state="new">Are you sure you want to delete this demo(s) from data cache?
-This will not delete this demo(s) from your HDD.</target>
+          <target state="needs-review">Вы уверены, что хотите удалить эти демки из кэша?
+Это действие не удалит эти демки с вашего диска.</target>
         </trans-unit>
         <trans-unit id="DialogRestartSteam" translate="yes" xml:space="preserve">
           <source>You have to restart Steam.</source>
-          <target state="new">You have to restart Steam.</target>
+          <target state="needs-review">Вы должны перезапустить Steam.</target>
         </trans-unit>
         <trans-unit id="DialogSelectAccountFirst" translate="yes" xml:space="preserve">
           <source>You have to select an account first.</source>
-          <target state="new">You have to select an account first.</target>
+          <target state="needs-review">Сначала вы должны выбрать аккаунт.</target>
         </trans-unit>
         <trans-unit id="DialogSendToRecycleBinConfimation" translate="yes" xml:space="preserve">
           <source>Are you sure you want to send this demo(s) to Recycle Bin?</source>
-          <target state="new">Are you sure you want to send this demo(s) to Recycle Bin?</target>
+          <target state="needs-review">Вы уверены, что хотите отправить эти демки в Корзину?</target>
         </trans-unit>
         <trans-unit id="DialogSetAccountToFocus" translate="yes" xml:space="preserve">
           <source>You have to set the account that you want to focus from settings to be able to use this feature.</source>
-          <target state="new">You have to set the account that you want to focus from settings to be able to use this feature.</target>
+          <target state="needs-review">Вы должны выбрать аккаунт, на котором хотите сфокусироваться, чтобы использовать эту функцию.</target>
         </trans-unit>
         <trans-unit id="DialogSetFolderForDownload" translate="yes" xml:space="preserve">
           <source>You have to select the folder where demos will be saved from settings.</source>
-          <target state="new">You have to select the folder where demos will be saved from settings.</target>
+          <target state="needs-review">Вы должны в настройках выбрать папку, в которую будут сохраняться демки.</target>
         </trans-unit>
         <trans-unit id="DialogSteamNotFound" translate="yes" xml:space="preserve">
           <source>Steam doesn't seems to be installed.
 Unable to start the game.</source>
-          <target state="new">Steam doesn't seems to be installed.
-Unable to start the game.</target>
+          <target state="needs-review">Похоже, Steam не установлен.
+Невозможно запустить игру.</target>
         </trans-unit>
         <trans-unit id="DialogSteamNotRunningOrNotLoggedIn" translate="yes" xml:space="preserve">
           <source>Steam is not running or you are not connected to a Steam account.</source>
-          <target state="new">Steam is not running or you are not connected to a Steam account.</target>
+          <target state="needs-review">Steam не запущен или вы не подключены к Steam аккаунту.</target>
         </trans-unit>
         <trans-unit id="Error" translate="yes" xml:space="preserve">
           <source>Error</source>
-          <target state="new">Error</target>
+          <target state="needs-review">Ошибка</target>
         </trans-unit>
         <trans-unit id="Export" translate="yes" xml:space="preserve">
           <source>Export</source>
-          <target state="new">Export</target>
+          <target state="needs-review">Экспорт</target>
         </trans-unit>
         <trans-unit id="Multiple" translate="yes" xml:space="preserve">
           <source>Multiple</source>
-          <target state="new">Multiple</target>
+          <target state="needs-review">В множество</target>
         </trans-unit>
         <trans-unit id="NotificationAddingSuspects" translate="yes" xml:space="preserve">
           <source>Adding suspects...</source>
-          <target state="new">Adding suspects...</target>
+          <target state="needs-review">Добавление подозреваемых...</target>
         </trans-unit>
         <trans-unit id="NotificationAnalyzingForJsonExport" translate="yes" xml:space="preserve">
           <source>Analyzing demo(s) for json export...</source>
-          <target state="new">Analyzing demo(s) for json export...</target>
+          <target state="needs-review">Анализ демок для экспорта json...</target>
         </trans-unit>
         <trans-unit id="NotificationAnalyzingMultipleDemos" translate="yes" xml:space="preserve">
           <source>Analyzing multiple demos...</source>
-          <target state="new">Analyzing multiple demos...</target>
+          <target state="needs-review">Анализ множества демок...</target>
         </trans-unit>
         <trans-unit id="NotificationCancelling" translate="yes" xml:space="preserve">
           <source>Cancelling...</source>
-          <target state="new">Cancelling...</target>
+          <target state="needs-review">Отмена...</target>
         </trans-unit>
         <trans-unit id="NotificationCheckingNewBanned" translate="yes" xml:space="preserve">
           <source>Checking for new banned suspects...</source>
-          <target state="new">Checking for new banned suspects...</target>
+          <target state="needs-review">Проверка на новых забаненных подозреваемых...</target>
         </trans-unit>
         <trans-unit id="NotificationDownloadingDemo" translate="yes" xml:space="preserve">
           <source>Downloading demo {0}/{1}...</source>
-          <target state="new">Downloading demo {0}/{1}...</target>
+          <target state="needs-review">Загружается демка {0}/{1}...</target>
         </trans-unit>
         <trans-unit id="NotificationExportingDemo" translate="yes" xml:space="preserve">
           <source>Exporting demo {0}...</source>
-          <target state="new">Exporting demo {0}...</target>
+          <target state="needs-review">Экспортируется демка {0}...</target>
         </trans-unit>
         <trans-unit id="NotificationExtractingDemo" translate="yes" xml:space="preserve">
           <source>Extracting demo {0}/{1}...</source>
-          <target state="new">Extracting demo {0}/{1}...</target>
+          <target state="needs-review">Распаковывается демка {0}/{1}...</target>
         </trans-unit>
         <trans-unit id="NotificationInitCache" translate="yes" xml:space="preserve">
           <source>Initializing cache...</source>
-          <target state="new">Initializing cache...</target>
+          <target state="needs-review">Инициализация кэша...</target>
         </trans-unit>
         <trans-unit id="NotificationInThisFolder" translate="yes" xml:space="preserve">
           <source>in this folder</source>
-          <target state="new">in this folder</target>
+          <target state="needs-review">в эту папку</target>
         </trans-unit>
         <trans-unit id="NotificationLoading" translate="yes" xml:space="preserve">
           <source>Loading...</source>
-          <target state="new">Loading...</target>
+          <target state="needs-review">Загрузка...</target>
         </trans-unit>
         <trans-unit id="NotificationLoadingAllDemos" translate="yes" xml:space="preserve">
           <source>Loading all demos...</source>
-          <target state="new">Loading all demos...</target>
+          <target state="needs-review">Загрузка всех демок...</target>
         </trans-unit>
         <trans-unit id="NotificationLoadingDemos" translate="yes" xml:space="preserve">
           <source>Loading demos...</source>
-          <target state="new">Loading demos...</target>
+          <target state="needs-review">Загрузка демок...</target>
         </trans-unit>
         <trans-unit id="NotificationLoadingMoreDemos" translate="yes" xml:space="preserve">
           <source>Loading more demos...</source>
-          <target state="new">Loading more demos...</target>
+          <target state="needs-review">Загрузка большего числа демок...</target>
         </trans-unit>
         <trans-unit id="NotificationNoDemosFound" translate="yes" xml:space="preserve">
           <source>No demos found</source>
-          <target state="new">No demos found</target>
+          <target state="needs-review">Демки не найдены</target>
         </trans-unit>
         <trans-unit id="NotificationNoDemosFoundForAccount" translate="yes" xml:space="preserve">
           <source>No demos found for this account</source>
-          <target state="new">No demos found for this account</target>
+          <target state="needs-review">Не найдены демки для этого аккаунта</target>
         </trans-unit>
         <trans-unit id="NotificationRetrievingMatchesData" translate="yes" xml:space="preserve">
           <source>Retrieving last matches information...</source>
-          <target state="new">Retrieving last matches information...</target>
+          <target state="needs-review">Получение информации о последних матчах...</target>
         </trans-unit>
         <trans-unit id="NotificationSearchingLastRank" translate="yes" xml:space="preserve">
           <source>Searching account's last rank...</source>
-          <target state="new">Searching account's last rank...</target>
+          <target state="needs-review">Поиск последнего ранга аккаунта...</target>
         </trans-unit>
         <trans-unit id="Ok" translate="yes" xml:space="preserve">
           <source>OK</source>
-          <target state="new">OK</target>
+          <target state="needs-review">ОК</target>
         </trans-unit>
         <trans-unit id="SaveHere" translate="yes" xml:space="preserve">
           <source>Save here</source>
-          <target state="new">Save here</target>
+          <target state="needs-review">Сохранить здесь</target>
         </trans-unit>
         <trans-unit id="Single" translate="yes" xml:space="preserve">
           <source>Single</source>
-          <target state="new">Single</target>
+          <target state="needs-review">В один</target>
         </trans-unit>
         <trans-unit id="WinPercentage" translate="yes" xml:space="preserve">
           <source>Win percentage</source>
-          <target state="new">Win percentage</target>
+          <target state="needs-review">Процент побед</target>
         </trans-unit>
         <trans-unit id="AllFemale" translate="yes" xml:space="preserve">
           <source>All</source>
-          <target state="new">All</target>
+          <target state="needs-review">Все</target>
         </trans-unit>
         <trans-unit id="CacheSize" translate="yes" xml:space="preserve">
           <source>Cache size</source>
-          <target state="new">Cache size</target>
+          <target state="needs-review">Размер кэша</target>
         </trans-unit>
         <trans-unit id="DialogAccountAlreadyInList" translate="yes" xml:space="preserve">
           <source>This player is already in your accounts list.</source>
-          <target state="new">This player is already in your accounts list.</target>
+          <target state="needs-review">Этот игрок уже в списке аккаунтов.</target>
         </trans-unit>
         <trans-unit id="DialogAddAnAccount" translate="yes" xml:space="preserve">
           <source>Add an account</source>
-          <target state="new">Add an account</target>
+          <target state="needs-review">Добавить аккаунт</target>
         </trans-unit>
         <trans-unit id="DialogAnalyzeAllDemosConfirmation" translate="yes" xml:space="preserve">
           <source>Do you want to analyze only the selected demos or all the demos within the selected folder?</source>
-          <target state="new">Do you want to analyze only the selected demos or all the demos within the selected folder?</target>
+          <target state="needs-review">Вы хотите проанализировать только выбранные демки или все демки внутри выбранной папки?</target>
         </trans-unit>
         <trans-unit id="DialogBackupCreated" translate="yes" xml:space="preserve">
           <source>The backup file has been created, you can re-import it from settings.</source>
-          <target state="new">The backup file has been created, you can re-import it from settings.</target>
+          <target state="needs-review">Резервная копия была создана, вы можете снова импортировать её в настройках.</target>
         </trans-unit>
         <trans-unit id="DialogConfirmDeleteDemosData" translate="yes" xml:space="preserve">
           <source>Demos data will be deleted! Are you sure?</source>
-          <target state="new">Demos data will be deleted! Are you sure?</target>
+          <target state="needs-review">Данные демок будут удалены! Вы уверены?</target>
         </trans-unit>
         <trans-unit id="DialogCustomDataImported" translate="yes" xml:space="preserve">
           <source>Custom data has been imported.</source>
-          <target state="new">Custom data has been imported.</target>
+          <target state="needs-review">Выборочные данные были импортированы.</target>
         </trans-unit>
         <trans-unit id="DialogDeleteVdmFilesConfirmation" translate="yes" xml:space="preserve">
           <source>All VDM files within your folders will be deleted, are you sure?</source>
-          <target state="new">All VDM files within your folders will be deleted, are you sure?</target>
+          <target state="needs-review">Все VDM файлы внутри ваших папок будут удалены, вы уверены?</target>
         </trans-unit>
         <trans-unit id="DialogDemosDataCleared" translate="yes" xml:space="preserve">
           <source>Demos data cleared.</source>
-          <target state="new">Demos data cleared.</target>
+          <target state="needs-review">Данные демок зачищены.</target>
         </trans-unit>
         <trans-unit id="DialogEnterSteamId" translate="yes" xml:space="preserve">
           <source>Enter the SteamID 64 or the Steam community URL.</source>
-          <target state="new">Enter the SteamID 64 or the Steam community URL.</target>
+          <target state="needs-review">Введите SteamID 64 или ссылку Steam сообщества.</target>
         </trans-unit>
         <trans-unit id="DialogErrorCreatingBackupFile" translate="yes" xml:space="preserve">
           <source>An error occured while exporting custom data.</source>
-          <target state="new">An error occured while exporting custom data.</target>
+          <target state="needs-review">Возникла ошибка при экспорте выборочных данных.</target>
         </trans-unit>
         <trans-unit id="DialogErrorDeletingVdmFiles" translate="yes" xml:space="preserve">
           <source>An error occured while deleting VDM files.</source>
-          <target state="new">An error occured while deleting VDM files.</target>
+          <target state="needs-review">Возникла ошибка при удалении VDM файлов.</target>
         </trans-unit>
         <trans-unit id="DialogErrorImportingCustomData" translate="yes" xml:space="preserve">
           <source>An error occured while importing custom data. The backup file may be corrupt.</source>
-          <target state="new">An error occured while importing custom data. The backup file may be corrupt.</target>
+          <target state="needs-review">Возникла ошибка при импорте выборочных данных. Резервная копия может быть повреждена.</target>
         </trans-unit>
         <trans-unit id="DialogErrorInvalidSteamId" translate="yes" xml:space="preserve">
           <source>Invalid SteamID 64 or Steam community URL.</source>
-          <target state="new">Invalid SteamID 64 or Steam community URL.</target>
+          <target state="needs-review">Неверный SteamID 64 или ссылка Steam сообщества.</target>
         </trans-unit>
         <trans-unit id="DialogErrorRemovingAccount" translate="yes" xml:space="preserve">
           <source>An error occured while removing the account.</source>
-          <target state="new">An error occured while removing the account.</target>
+          <target state="needs-review">Возникла ошибка при удалении аккаунта.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileRetrievingPlayerInformation" translate="yes" xml:space="preserve">
           <source>Error while trying to get player information.</source>
-          <target state="new">Error while trying to get player information.</target>
+          <target state="needs-review">Ошибка при получении информации об игроке.</target>
         </trans-unit>
         <trans-unit id="DialogNoErrorsFile" translate="yes" xml:space="preserve">
           <source>There is no errors log file.</source>
-          <target state="new">There is no errors log file.</target>
+          <target state="needs-review">Файл errors.log не найден.</target>
         </trans-unit>
         <trans-unit id="DialogSelectCsgoPath" translate="yes" xml:space="preserve">
           <source>Please select the csgo.exe file location to enable it.</source>
-          <target state="new">Please select the csgo.exe file location to enable it.</target>
+          <target state="needs-review">Пожалуйста выберите расположение файла csgo.exe, чтобы включить эту опцию'.</target>
         </trans-unit>
         <trans-unit id="DialogVdmFilesDeleted" translate="yes" xml:space="preserve">
           <source>VDM files deleted.</source>
-          <target state="new">VDM files deleted.</target>
+          <target state="needs-review">VDM файлы удалены.</target>
         </trans-unit>
         <trans-unit id="MegaByte" translate="yes" xml:space="preserve">
           <source>MB</source>
-          <target state="new">MB</target>
+          <target state="needs-review">МБ</target>
         </trans-unit>
         <trans-unit id="NotificationAddingAccount" translate="yes" xml:space="preserve">
           <source>Adding account...</source>
-          <target state="new">Adding account...</target>
+          <target state="needs-review">Добавление аккаунта...</target>
         </trans-unit>
         <trans-unit id="NotificationSyncingAccountsNickname" translate="yes" xml:space="preserve">
           <source>Syncing accounts nickname...</source>
-          <target state="new">Syncing accounts nickname...</target>
+          <target state="needs-review">Синхронизация никнеймов аккаунта...</target>
         </trans-unit>
         <trans-unit id="PlayerPov" translate="yes" xml:space="preserve">
           <source>Player POV</source>
-          <target state="new">Player POV</target>
+          <target state="needs-review">POV Игрока</target>
         </trans-unit>
         <trans-unit id="Selection" translate="yes" xml:space="preserve">
           <source>Selection</source>
-          <target state="new">Selection</target>
+          <target state="needs-review">Выбор</target>
         </trans-unit>
         <trans-unit id="ToolTipDisplaySettings" translate="yes" xml:space="preserve">
           <source>Display settings</source>
-          <target state="new">Display settings</target>
+          <target state="needs-review">Настройки дисплея</target>
         </trans-unit>
         <trans-unit id="DialogAnalyzeRequired" translate="yes" xml:space="preserve">
           <source>You have to analyze this demo first.</source>
-          <target state="new">You have to analyze this demo first.</target>
+          <target state="needs-review">Сначала нужно проанализировать эту демку.</target>
         </trans-unit>
         <trans-unit id="DialogBoilerIncorrect" translate="yes" xml:space="preserve">
           <source>boiler.exe is incorrect.</source>
-          <target state="new">boiler.exe is incorrect.</target>
+          <target state="needs-review">Файл boiler.exe некорректный.</target>
         </trans-unit>
         <trans-unit id="DialogDemosNotFound" translate="yes" xml:space="preserve">
           <source>The following demos have not been found:</source>
-          <target state="new">The following demos have not been found:</target>
+          <target state="needs-review">Следующие демки не были найдены:</target>
         </trans-unit>
         <trans-unit id="DialogErrorDemoNotFound" translate="yes" xml:space="preserve">
           <source>Demo {0} not found.</source>
-          <target state="new">Demo {0} not found.</target>
+          <target state="needs-review">Демка {0} не найдена.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileAnalyzingDemo" translate="yes" xml:space="preserve">
           <source>An error occurred while analyzing the demo {0}.
@@ -2561,828 +2561,828 @@ Unable to start the game.</target>
 
 Please create an issue on GitHub with the affected demo only if it comes from a supported source.
 You can find more information on {1}.</source>
-          <target state="new">An error occurred while analyzing the demo {0}.
-- Make sure the demo's source is correct.
-- POV demos are not supported.
-- Demos coming from a custom server are not officially supported and thus may not work properly, you can try to change the demo's source and re-analyze it.
+          <target state="needs-review">Произошла ошибка при анализе демки {0}.
+- Убедитесь, что источник демки указан верно.
+- POV демки не поддерживаются.
+- Демки, взятые с пользовательского сервера, официально не поддерживаются и поэтому могут работать некорректно, вы можете попробовать изменить источник демки и повторно проанализировать её.
 
-Please create an issue on GitHub with the affected demo only if it comes from a supported source.
-You can find more information on {1}.</target>
+Пожалуйста создавайте заявку на GitHub с упомянутой демкой, только если она получена из поддерживаемого источника. 
+Дополнительную информацию вы можете найти на {1}.</target>
         </trans-unit>
         <trans-unit id="DialogMapNotSupported" translate="yes" xml:space="preserve">
           <source>This map doesn't support this feature.</source>
-          <target state="new">This map doesn't support this feature.</target>
+          <target state="needs-review">Эта карта не поддерживает эту функцию.</target>
         </trans-unit>
         <trans-unit id="DialogNoConnexionDetected" translate="yes" xml:space="preserve">
           <source>No Internet Connection</source>
-          <target state="new">No Internet Connection</target>
+          <target state="needs-review">Нет Интернета</target>
         </trans-unit>
         <trans-unit id="DialogNoConnexionNoFeature" translate="yes" xml:space="preserve">
           <source>No Internet connection detected, you can't use this feature.</source>
-          <target state="new">No Internet connection detected, you can't use this feature.</target>
+          <target state="needs-review">Нет Интернета, вы не можете использовать эту функцию.</target>
         </trans-unit>
         <trans-unit id="DialogPovSelection" translate="yes" xml:space="preserve">
           <source>Which POV (camera perspective) do you want to see?</source>
-          <target state="new">Which POV (camera perspective) do you want to see?</target>
+          <target state="needs-review">Чью POV (перспективу камеры) вы хотите увидеть?</target>
         </trans-unit>
         <trans-unit id="EnemyPov" translate="yes" xml:space="preserve">
           <source>Enemy POV</source>
-          <target state="new">Enemy POV</target>
+          <target state="needs-review">POV Врага</target>
         </trans-unit>
         <trans-unit id="NotificationAnalyzing" translate="yes" xml:space="preserve">
           <source>Analyzing...</source>
-          <target state="new">Analyzing...</target>
+          <target state="needs-review">Анализ...</target>
         </trans-unit>
         <trans-unit id="NotificationAnalyzingDemo" translate="yes" xml:space="preserve">
           <source>Analyzing demo {0}...</source>
-          <target state="new">Analyzing demo {0}...</target>
+          <target state="needs-review">Анализ демки {0}...</target>
         </trans-unit>
         <trans-unit id="Pov" translate="yes" xml:space="preserve">
           <source>POV</source>
-          <target state="new">POV</target>
+          <target state="needs-review">POV</target>
         </trans-unit>
         <trans-unit id="Add" translate="yes" xml:space="preserve">
           <source>Add</source>
-          <target state="new">Add</target>
+          <target state="needs-review">Добавить</target>
         </trans-unit>
         <trans-unit id="AddAllPlayersSeen" translate="yes" xml:space="preserve">
           <source>Add all players seen</source>
-          <target state="new">Add all players seen</target>
+          <target state="needs-review">Добавить всех увиденных игроков</target>
         </trans-unit>
         <trans-unit id="Both" translate="yes" xml:space="preserve">
           <source>Both</source>
-          <target state="new">Both</target>
+          <target state="needs-review">Оба</target>
         </trans-unit>
         <trans-unit id="CounterTerrorists" translate="yes" xml:space="preserve">
           <source>Counter-Terrorists</source>
-          <target state="new">Counter-Terrorists</target>
+          <target state="needs-review">Контр-Террористы</target>
         </trans-unit>
         <trans-unit id="DialogNoPointsFound" translate="yes" xml:space="preserve">
           <source>No points found. You may have to analyze this demo.</source>
-          <target state="new">No points found. You may have to analyze this demo.</target>
+          <target state="needs-review">Точек не найдено. Вы должны проанализировать эту демку.</target>
         </trans-unit>
         <trans-unit id="Equipment" translate="yes" xml:space="preserve">
           <source>Equipment</source>
-          <target state="new">Equipment</target>
+          <target state="needs-review">Экипировка</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipKnifeKills" translate="yes" xml:space="preserve">
           <source>Knife Kills</source>
-          <target state="new">Knife Kills</target>
+          <target state="needs-review">Убийства Ножом</target>
         </trans-unit>
         <trans-unit id="HeadshotsPercent" translate="yes" xml:space="preserve">
           <source>Headshots %</source>
-          <target state="new">Headshots %</target>
+          <target state="needs-review">Убийства в голову %</target>
         </trans-unit>
         <trans-unit id="LabelScale" translate="yes" xml:space="preserve">
           <source>Scale</source>
-          <target state="new">Scale</target>
+          <target state="needs-review">Масштаб</target>
         </trans-unit>
         <trans-unit id="LabelSpeed" translate="yes" xml:space="preserve">
           <source>Speed</source>
-          <target state="new">Speed</target>
+          <target state="needs-review">Скорость</target>
         </trans-unit>
         <trans-unit id="LabelVolume" translate="yes" xml:space="preserve">
           <source>Volume</source>
-          <target state="new">Volume</target>
+          <target state="needs-review">Громкость</target>
         </trans-unit>
         <trans-unit id="LogOnlyKills" translate="yes" xml:space="preserve">
           <source>Log only kills</source>
-          <target state="new">Log only kills</target>
+          <target state="needs-review">Записывать только убийства</target>
         </trans-unit>
         <trans-unit id="NotificationGeneratingData" translate="yes" xml:space="preserve">
           <source>Generating data...</source>
-          <target state="new">Generating data...</target>
+          <target state="needs-review">Генерация данных...</target>
         </trans-unit>
         <trans-unit id="NotificationPaused" translate="yes" xml:space="preserve">
           <source>Paused</source>
-          <target state="new">Paused</target>
+          <target state="needs-review">Приостановлено</target>
         </trans-unit>
         <trans-unit id="NotificationPlaying" translate="yes" xml:space="preserve">
           <source>Playing...</source>
-          <target state="new">Playing...</target>
+          <target state="needs-review">Проигрывается...</target>
         </trans-unit>
         <trans-unit id="Pause" translate="yes" xml:space="preserve">
           <source>Pause</source>
-          <target state="new">Pause</target>
+          <target state="needs-review">Пауза</target>
         </trans-unit>
         <trans-unit id="Play" translate="yes" xml:space="preserve">
           <source>Play</source>
-          <target state="new">Play</target>
+          <target state="needs-review">Воспроизведение</target>
         </trans-unit>
         <trans-unit id="ShowOnlyBanned" translate="yes" xml:space="preserve">
           <source>Show only banned</source>
-          <target state="new">Show only banned</target>
+          <target state="needs-review">Показать только забаненных</target>
         </trans-unit>
         <trans-unit id="ShowSuspectsDemos" translate="yes" xml:space="preserve">
           <source>Show suspect(s) demos</source>
-          <target state="new">Show suspect(s) demos</target>
+          <target state="needs-review">Показать демки подозреваемых</target>
         </trans-unit>
         <trans-unit id="Side" translate="yes" xml:space="preserve">
           <source>Side</source>
-          <target state="new">Side</target>
+          <target state="needs-review">Сторона</target>
         </trans-unit>
         <trans-unit id="StuffsThrown" translate="yes" xml:space="preserve">
           <source>Stuffs Thrown</source>
-          <target state="new">Stuffs Thrown</target>
+          <target state="needs-review">Вещей Брошено</target>
         </trans-unit>
         <trans-unit id="Terrorists" translate="yes" xml:space="preserve">
           <source>Terrorists</source>
-          <target state="new">Terrorists</target>
+          <target state="needs-review">Террористы</target>
         </trans-unit>
         <trans-unit id="ToolTipAddAllPlayersSeen" translate="yes" xml:space="preserve">
           <source>Add all players seen to list (CTRL+G)</source>
-          <target state="new">Add all players seen to list (CTRL+G)</target>
+          <target state="needs-review">Добавить всех увиденных игроков в список (CTRL+G)</target>
         </trans-unit>
         <trans-unit id="ToolTipGoToSuspectProfile" translate="yes" xml:space="preserve">
           <source>Go to suspect profile (CTRL+P)</source>
-          <target state="new">Go to suspect profile (CTRL+P)</target>
+          <target state="needs-review">Перейти к профилю подозреваемого (CTRL+P)</target>
         </trans-unit>
         <trans-unit id="ToolTipMoveSuspectToWhitelist" translate="yes" xml:space="preserve">
           <source>Move suspect(s) to whitelist (CTRL+M)</source>
-          <target state="new">Move suspect(s) to whitelist (CTRL+M)</target>
+          <target state="needs-review">Перенести подозреваемых в белый список (CTRL+M)</target>
         </trans-unit>
         <trans-unit id="ToolTipPause" translate="yes" xml:space="preserve">
           <source>Pause (CTRL+O)</source>
-          <target state="new">Pause (CTRL+O)</target>
+          <target state="needs-review">Приостановить (CTRL+O)</target>
         </trans-unit>
         <trans-unit id="ToolTipPlay" translate="yes" xml:space="preserve">
           <source>Play (CTRL+P)</source>
-          <target state="new">Play (CTRL+P)</target>
+          <target state="needs-review">Воспроизвести (CTRL+P)</target>
         </trans-unit>
         <trans-unit id="ToolTipRefreshList" translate="yes" xml:space="preserve">
           <source>Refresh list (CTRL+R)</source>
-          <target state="new">Refresh list (CTRL+R)</target>
+          <target state="needs-review">Обновить список (CTRL+R)</target>
         </trans-unit>
         <trans-unit id="ToolTipRemoveSuspect" translate="yes" xml:space="preserve">
           <source>Remove suspect(s) (DEL)</source>
-          <target state="new">Remove suspect(s) (DEL)</target>
+          <target state="needs-review">Убрать подозреваемых (DEL)</target>
         </trans-unit>
         <trans-unit id="ToolTIpShowOnlySuspectDemos" translate="yes" xml:space="preserve">
           <source>Show demos that contains selected suspect(s) (CTRL+F)</source>
-          <target state="new">Show demos that contains selected suspect(s) (CTRL+F)</target>
+          <target state="needs-review">Показать демки, содержащие выбранных подозреваемых (CTRL+F)</target>
         </trans-unit>
         <trans-unit id="ToolTipWhitelist" translate="yes" xml:space="preserve">
           <source>Whitelist (CTRL+W)</source>
-          <target state="new">Whitelist (CTRL+W)</target>
+          <target state="needs-review">Белый список (CTRL+W)</target>
         </trans-unit>
         <trans-unit id="WatermarkSearch" translate="yes" xml:space="preserve">
           <source>Search...</source>
-          <target state="new">Search...</target>
+          <target state="needs-review">Поиск...</target>
         </trans-unit>
         <trans-unit id="Whitelist" translate="yes" xml:space="preserve">
           <source>Whitelist</source>
-          <target state="new">Whitelist</target>
+          <target state="needs-review">Белый список</target>
         </trans-unit>
         <trans-unit id="DialogAddPlayerToWhitelist" translate="yes" xml:space="preserve">
           <source>Add a player to whitelist</source>
-          <target state="new">Add a player to whitelist</target>
+          <target state="needs-review">Добавить игрока в белый список</target>
         </trans-unit>
         <trans-unit id="DialogAddSuspect" translate="yes" xml:space="preserve">
           <source>Add a suspect</source>
-          <target state="new">Add a suspect</target>
+          <target state="needs-review">Добавить подозреваемого</target>
         </trans-unit>
         <trans-unit id="DialogCsgoNotDetected" translate="yes" xml:space="preserve">
           <source>It seems that CSGO is not installed on your main hard drive.
 The defaults "csgo" and "replays" can not be found. Please add folders from the settings.</source>
-          <target state="new">It seems that CSGO is not installed on your main hard drive.
-The defaults "csgo" and "replays" can not be found. Please add folders from the settings.</target>
+          <target state="needs-review">Похоже, CSGO не установлена на вашем основном жестком диске.
+Не удается найти папки «csgo» и «replays». Пожалуйста добавьте папки через настройки.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileDeletingPlayer" translate="yes" xml:space="preserve">
           <source>Error while deleting player.</source>
-          <target state="new">Error while deleting player.</target>
+          <target state="needs-review">Ошибка при удалении игрока.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileDeletingSuspect" translate="yes" xml:space="preserve">
           <source>Error while deleting suspect.</source>
-          <target state="new">Error while deleting suspect.</target>
+          <target state="needs-review">Ошибка при удалении подозреваемого.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileExportingCustomData" translate="yes" xml:space="preserve">
           <source>An error occured while exporting custom data.</source>
-          <target state="new">An error occured while exporting custom data.</target>
+          <target state="needs-review">Возникла ошибка при экспорте выборочных данных.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileMovingSuspects" translate="yes" xml:space="preserve">
           <source>Error while moving suspect(s).</source>
-          <target state="new">Error while moving suspect(s).</target>
+          <target state="needs-review">Ошибка при перемещении подозреваемых.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileRetrievingPlayersInformation" translate="yes" xml:space="preserve">
           <source>Error while trying to get players information.</source>
-          <target state="new">Error while trying to get players information.</target>
+          <target state="needs-review">Ошибка при получении информации об игроках.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileRetrievingSuspectInformation" translate="yes" xml:space="preserve">
           <source>Error while trying to get suspect information.</source>
-          <target state="new">Error while trying to get suspect information.</target>
+          <target state="needs-review">Ошибка при получении информации о подозреваемом.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileRetrievingSuspectsInformation" translate="yes" xml:space="preserve">
           <source>Error while trying to get suspects information.</source>
-          <target state="new">Error while trying to get suspects information.</target>
+          <target state="needs-review">Ошибка при получении информации о подозреваемых.</target>
         </trans-unit>
         <trans-unit id="DialogNewVersionAvailable" translate="yes" xml:space="preserve">
           <source>A new version is available.
 Do you want to download it?</source>
-          <target state="new">A new version is available.
-Do you want to download it?</target>
+          <target state="needs-review">Доступна новая версия.
+Хотите её скачать?</target>
         </trans-unit>
         <trans-unit id="DialogNoDemosPlayerFound" translate="yes" xml:space="preserve">
           <source>No demos found for this player.
 Demos with this player might not have been analyzed.</source>
-          <target state="new">No demos found for this player.
-Demos with this player might not have been analyzed.</target>
+          <target state="needs-review">Не найдено демок этого игрока.
+Возможно, демки этого игрока не были проанализированы.</target>
         </trans-unit>
         <trans-unit id="DialogNoDemosSuspectFound" translate="yes" xml:space="preserve">
           <source>No demos found for this suspect.
 Demos with this suspect might not have been analyzed.</source>
-          <target state="new">No demos found for this suspect.
-Demos with this suspect might not have been analyzed.</target>
+          <target state="needs-review">Не найдено демок этого подозреваемого.
+Возможно, демки этого подозреваемого не были проанализированы.</target>
         </trans-unit>
         <trans-unit id="DialogPlayerAlreadyInSuspectWhitelist" translate="yes" xml:space="preserve">
           <source>This player is in your suspect / white / account list.
 You have to remove it from your account and white list to be able to add him in your supect list.</source>
-          <target state="new">This player is in your suspect / white / account list.
-You have to remove it from your account and white list to be able to add him in your supect list.</target>
+          <target state="needs-review">Этот игрок уже в списке подозреваемых / аккаунтов / белом списке.
+Вы должны удалить его из списка аккаунтов и из белого списка, чтобы добавить его в список подозреваемых.</target>
         </trans-unit>
         <trans-unit id="DialogUpdateRequireClearCache" translate="yes" xml:space="preserve">
           <source>This update requires to clear custom data from cache (your suspects list will not be removed).
 Do you want to save your custom data?</source>
-          <target state="new">This update requires to clear custom data from cache (your suspects list will not be removed).
-Do you want to save your custom data?</target>
+          <target state="needs-review">Это обновление требует очистить выборочные данные из кэша (ваш список подозреваемых не будет затронут).
+Вы хотите соъранить ваши выборочные данные?</target>
         </trans-unit>
         <trans-unit id="DialogPlayerNotFound" translate="yes" xml:space="preserve">
           <source>Player not found.</source>
-          <target state="new">Player not found.</target>
+          <target state="needs-review">Игрок не найден.</target>
         </trans-unit>
         <trans-unit id="HeaderAccountVisibility" translate="yes" xml:space="preserve">
           <source>Account visibility</source>
-          <target state="new">Account visibility</target>
+          <target state="needs-review">Видимость аккаунта</target>
         </trans-unit>
         <trans-unit id="HeaderBanCount" translate="yes" xml:space="preserve">
           <source>Ban Count</source>
-          <target state="new">Ban Count</target>
+          <target state="needs-review">Счётчик банов</target>
         </trans-unit>
         <trans-unit id="HeaderCommunityBanned" translate="yes" xml:space="preserve">
           <source>Community Banned</source>
-          <target state="new">Community Banned</target>
+          <target state="needs-review">Забанен в Сообществе</target>
         </trans-unit>
         <trans-unit id="HeaderDaysSinceLastBan" translate="yes" xml:space="preserve">
           <source>DSLB</source>
-          <target state="new">DSLB</target>
+          <target state="needs-review">ДСПБ</target>
         </trans-unit>
         <trans-unit id="HeaderEconomyBanned" translate="yes" xml:space="preserve">
           <source>Economy Banned</source>
-          <target state="new">Economy Banned</target>
+          <target state="needs-review">Экономика Забанена</target>
         </trans-unit>
         <trans-unit id="HeaderGameBan" translate="yes" xml:space="preserve">
           <source>Game ban</source>
-          <target state="new">Game ban</target>
+          <target state="needs-review">Игровой бан</target>
         </trans-unit>
         <trans-unit id="HeaderNickname" translate="yes" xml:space="preserve">
           <source>Nickname</source>
-          <target state="new">Nickname</target>
+          <target state="needs-review">Никнейм</target>
         </trans-unit>
         <trans-unit id="HeaderProfileSetup" translate="yes" xml:space="preserve">
           <source>Profile setup</source>
-          <target state="new">Profile setup</target>
+          <target state="needs-review">Настройка профиля</target>
         </trans-unit>
         <trans-unit id="NotificationAddingPlayerToWhitelist" translate="yes" xml:space="preserve">
           <source>Adding player to whitelist...</source>
-          <target state="new">Adding player to whitelist...</target>
+          <target state="needs-review">Добавление игрока в белый список...</target>
         </trans-unit>
         <trans-unit id="NotificationAddingSuspect" translate="yes" xml:space="preserve">
           <source>Adding suspect...</source>
-          <target state="new">Adding suspect...</target>
+          <target state="needs-review">Добавление подозреваемого...</target>
         </trans-unit>
         <trans-unit id="NotificationMovingSuspectsToWhitelist" translate="yes" xml:space="preserve">
           <source>Moving suspect(s) to whitelist...</source>
-          <target state="new">Moving suspect(s) to whitelist...</target>
+          <target state="needs-review">Перемещение подозреваемых в белый список...</target>
         </trans-unit>
         <trans-unit id="NotificationPlayerAlreadyInWhitelist" translate="yes" xml:space="preserve">
           <source>Player already in your whitelist.</source>
-          <target state="new">Player already in your whitelist.</target>
+          <target state="needs-review">Игрок уже в вашем белом списке.</target>
         </trans-unit>
         <trans-unit id="NotificationRefreshing" translate="yes" xml:space="preserve">
           <source>Refreshing...</source>
-          <target state="new">Refreshing...</target>
+          <target state="needs-review">Обновление...</target>
         </trans-unit>
         <trans-unit id="NotificationSearching" translate="yes" xml:space="preserve">
           <source>Searching...</source>
-          <target state="new">Searching...</target>
+          <target state="needs-review">Поиск...</target>
         </trans-unit>
         <trans-unit id="NotificationStoppingAnalyze" translate="yes" xml:space="preserve">
           <source>Stopping analyze...</source>
-          <target state="new">Stopping analyze...</target>
+          <target state="needs-review">Остановка анализа...</target>
         </trans-unit>
         <trans-unit id="Dark" translate="yes" xml:space="preserve">
           <source>Dark</source>
-          <target state="new">Dark</target>
+          <target state="needs-review">Тёмная</target>
         </trans-unit>
         <trans-unit id="Day" translate="yes" xml:space="preserve">
           <source>Day</source>
-          <target state="new">Day</target>
+          <target state="needs-review">День</target>
         </trans-unit>
         <trans-unit id="DialogErrorExportingHeatmap" translate="yes" xml:space="preserve">
           <source>An error occured while exporting heatmap to PNG.</source>
-          <target state="new">An error occured while exporting heatmap to PNG.</target>
+          <target state="needs-review">Возникла ошибка при экспорте тепловой карты в PNG.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileAddingPlayerToSuspectsList" translate="yes" xml:space="preserve">
           <source>Error while adding player to suspects list.</source>
-          <target state="new">Error while adding player to suspects list.</target>
+          <target state="needs-review">Ошибка при добавлении игрока в список подозреваемых.</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileAddingPlayerToWhitelist" translate="yes" xml:space="preserve">
           <source>Error while adding player to whitelist.</source>
-          <target state="new">Error while adding player to whitelist.</target>
+          <target state="needs-review">Ошибка при добавлении игрока в белый список.</target>
         </trans-unit>
         <trans-unit id="DialogNoDamagesDataFound" translate="yes" xml:space="preserve">
           <source>No damages data found.
 The demo is too old or you didn't analyze it.</source>
-          <target state="new">No damages data found.
-The demo is too old or you didn't analyze it.</target>
+          <target state="needs-review">Нет данных об уроне.
+Демка слишком старая или вы не анализировали её.</target>
         </trans-unit>
         <trans-unit id="DialogNoDemosFoundForPlayer" translate="yes" xml:space="preserve">
           <source>No demos found for this player.
 Demos with this player might not have been analyzed.</source>
-          <target state="new">No demos found for this player.
-Demos with this player might not have been analyzed.</target>
+          <target state="needs-review">Не найдено демок для этого игрока.
+Возможно, демки с этим игроком не проанализированы.</target>
         </trans-unit>
         <trans-unit id="DialogPlayerAlreadyInAccountsList" translate="yes" xml:space="preserve">
           <source>This player is already in your account list.</source>
-          <target state="new">This player is already in your account list.</target>
+          <target state="needs-review">Этот игрок уже в списке аккаунтов.</target>
         </trans-unit>
         <trans-unit id="DialogPlayerAlreadyInSuspectsList" translate="yes" xml:space="preserve">
           <source>This player is already in your suspect or he is in your account list.
 You have to remove it from your account list to be able to add him in your supect list.</source>
-          <target state="new">This player is already in your suspect or he is in your account list.
-You have to remove it from your account list to be able to add him in your supect list.</target>
+          <target state="needs-review">Этот игрок уже есть в списке подозреваемых или в списке аккаунтов.
+Вы должны удалить его из списка аккаунтов, чтобы добавить его в список подозреваемых.</target>
         </trans-unit>
         <trans-unit id="DialogPlayerAlreadyInWhitelist" translate="yes" xml:space="preserve">
           <source>This player is already in your whitelist or he is in your account list.
 You have to remove it from your account list to be able to add him in your whitelist.</source>
-          <target state="new">This player is already in your whitelist or he is in your account list.
-You have to remove it from your account list to be able to add him in your whitelist.</target>
+          <target state="needs-review">Этот игрок уже есть в белом списке или в списке аккаунтов.
+Вы должны удалить его из списка аккаунтов, чтобы добавить его в белый список.</target>
         </trans-unit>
         <trans-unit id="Light" translate="yes" xml:space="preserve">
           <source>Light</source>
-          <target state="new">Light</target>
+          <target state="needs-review">Светлая</target>
         </trans-unit>
         <trans-unit id="Month" translate="yes" xml:space="preserve">
           <source>Month</source>
-          <target state="new">Month</target>
+          <target state="needs-review">Месяц</target>
         </trans-unit>
         <trans-unit id="None" translate="yes" xml:space="preserve">
           <source>None</source>
-          <target state="new">None</target>
+          <target state="needs-review">Нет</target>
         </trans-unit>
         <trans-unit id="NotificationAddingPlayerToAccountsList" translate="yes" xml:space="preserve">
           <source>Adding player to the account list...</source>
-          <target state="new">Adding player to the account list...</target>
+          <target state="needs-review">Добавление игрока в список аккаунтов...</target>
         </trans-unit>
         <trans-unit id="NotificationAddingPlayerToSuspectsList" translate="yes" xml:space="preserve">
           <source>Adding player to suspects list...</source>
-          <target state="new">Adding player to suspects list...</target>
+          <target state="needs-review">Добавление игрока в список подозреваемых...</target>
         </trans-unit>
         <trans-unit id="NotificationCommentSaved" translate="yes" xml:space="preserve">
           <source>Comment saved.</source>
-          <target state="new">Comment saved.</target>
+          <target state="needs-review">Комментарий сохранен.</target>
         </trans-unit>
         <trans-unit id="NotificationPlayedAddedToSuspectsList" translate="yes" xml:space="preserve">
           <source>Player added to suspects list.</source>
-          <target state="new">Player added to suspects list.</target>
+          <target state="needs-review">Игрок добавлен в список подозреваемых.</target>
         </trans-unit>
         <trans-unit id="NotificationPlayerAddedToAccountsList" translate="yes" xml:space="preserve">
           <source>Player added to the account list.</source>
-          <target state="new">Player added to the account list.</target>
+          <target state="needs-review">Игрок добавлен в список аккаунтов.</target>
         </trans-unit>
         <trans-unit id="NotificationPlayerAddedToWhitelist" translate="yes" xml:space="preserve">
           <source>Player added to whitelist.</source>
-          <target state="new">Player added to whitelist.</target>
+          <target state="needs-review">Игрок добавлен в белый список.</target>
         </trans-unit>
         <trans-unit id="NotificationSearchingDemosForPlayer" translate="yes" xml:space="preserve">
           <source>Searching demos for this player...</source>
-          <target state="new">Searching demos for this player...</target>
+          <target state="needs-review">Поиск демок этого игрока...</target>
         </trans-unit>
         <trans-unit id="NotificationSetposCommandCopied" translate="yes" xml:space="preserve">
           <source>setpos command copied to clipboard</source>
-          <target state="new">setpos command copied to clipboard</target>
+          <target state="needs-review">Команда setpos скопирована в буфер обмена</target>
         </trans-unit>
         <trans-unit id="ShotsFired" translate="yes" xml:space="preserve">
           <source>Shots fired</source>
-          <target state="new">Shots fired</target>
+          <target state="needs-review">Выстрелов сделано</target>
         </trans-unit>
         <trans-unit id="Smokes" translate="yes" xml:space="preserve">
           <source>Smokes</source>
-          <target state="new">Smokes</target>
+          <target state="needs-review">Дымовые гранаты</target>
         </trans-unit>
         <trans-unit id="CT" translate="yes" xml:space="preserve">
           <source>CT</source>
-          <target state="new">CT</target>
+          <target state="needs-review">КТ</target>
         </trans-unit>
         <trans-unit id="Spec" translate="yes" xml:space="preserve">
           <source>SPEC</source>
-          <target state="new">SPEC</target>
+          <target state="needs-review">СПЕК</target>
         </trans-unit>
         <trans-unit id="T" translate="yes" xml:space="preserve">
           <source>T</source>
-          <target state="new">T</target>
+          <target state="needs-review">Т</target>
         </trans-unit>
         <trans-unit id="Lost" translate="yes" xml:space="preserve">
           <source>Lost</source>
-          <target state="new">Lost</target>
+          <target state="needs-review">Проиграно</target>
         </trans-unit>
         <trans-unit id="LostSurrender" translate="yes" xml:space="preserve">
           <source>Lost (S)</source>
-          <target state="new">Lost (S)</target>
+          <target state="needs-review">Проигрышь (С)</target>
         </trans-unit>
         <trans-unit id="WinSurrender" translate="yes" xml:space="preserve">
           <source>Win (S)</source>
-          <target state="new">Win (S)</target>
+          <target state="needs-review">Победа (С)</target>
         </trans-unit>
         <trans-unit id="Away" translate="yes" xml:space="preserve">
           <source>Away</source>
-          <target state="new">Away</target>
+          <target state="needs-review">Отсутствует</target>
         </trans-unit>
         <trans-unit id="Busy" translate="yes" xml:space="preserve">
           <source>Busy</source>
-          <target state="new">Busy</target>
+          <target state="needs-review">Занят</target>
         </trans-unit>
         <trans-unit id="LookingToPlay" translate="yes" xml:space="preserve">
           <source>Looking to play</source>
-          <target state="new">Looking to play</target>
+          <target state="needs-review">Хочет поиграть</target>
         </trans-unit>
         <trans-unit id="LookingToTrade" translate="yes" xml:space="preserve">
           <source>Looking to trade</source>
-          <target state="new">Looking to trade</target>
+          <target state="needs-review">Хочет торговать</target>
         </trans-unit>
         <trans-unit id="Offline" translate="yes" xml:space="preserve">
           <source>Offline</source>
-          <target state="new">Offline</target>
+          <target state="needs-review">Не в сети</target>
         </trans-unit>
         <trans-unit id="Online" translate="yes" xml:space="preserve">
           <source>Online</source>
-          <target state="new">Online</target>
+          <target state="needs-review">В сети</target>
         </trans-unit>
         <trans-unit id="Private" translate="yes" xml:space="preserve">
           <source>Private</source>
-          <target state="new">Private</target>
+          <target state="needs-review">Личный</target>
         </trans-unit>
         <trans-unit id="Public" translate="yes" xml:space="preserve">
           <source>Public</source>
-          <target state="new">Public</target>
+          <target state="needs-review">Публичный</target>
         </trans-unit>
         <trans-unit id="Snooze" translate="yes" xml:space="preserve">
           <source>Snooze</source>
-          <target state="new">Snooze</target>
+          <target state="needs-review">Спит</target>
         </trans-unit>
         <trans-unit id="ToolTipAbout" translate="yes" xml:space="preserve">
           <source>about</source>
-          <target state="new">about</target>
+          <target state="needs-review">около</target>
           <note from="MultilingualBuild" annotates="source" priority="2">used for heatmap flashbang tooltip (about x seconds)</note>
         </trans-unit>
         <trans-unit id="ToolTipAddToWhitelist" translate="yes" xml:space="preserve">
           <source>Add an account to whitelist</source>
-          <target state="new">Add an account to whitelist</target>
+          <target state="needs-review">Добавить аккаунт в белый список</target>
         </trans-unit>
         <trans-unit id="ToolTipBlinded" translate="yes" xml:space="preserve">
           <source>blinded</source>
-          <target state="new">blinded</target>
+          <target state="needs-review">ослепил</target>
           <note from="MultilingualBuild" annotates="source" priority="2">used for heatmap flashbang tooltip (player1 blinded player2)</note>
         </trans-unit>
         <trans-unit id="ToolTipBlindedOthersPlayersFor" translate="yes" xml:space="preserve">
           <source>blinded others players for</source>
-          <target state="new">blinded others players for</target>
+          <target state="needs-review">ослепил других игроков на</target>
           <note from="MultilingualBuild" annotates="source" priority="2">used for heatmap flashbang tooltip</note>
         </trans-unit>
         <trans-unit id="ToolTipGoToPlayerProfile" translate="yes" xml:space="preserve">
           <source>Go to player profile (CTRL+P)</source>
-          <target state="new">Go to player profile (CTRL+P)</target>
+          <target state="needs-review">Перейти к профилю игрока (CTRL+P)</target>
         </trans-unit>
         <trans-unit id="ToolTipKilled" translate="yes" xml:space="preserve">
           <source>killed</source>
-          <target state="new">killed</target>
+          <target state="needs-review">убил</target>
           <note from="MultilingualBuild" annotates="source" priority="2">used for heatmap flashbang tooltip</note>
         </trans-unit>
         <trans-unit id="ToolTipOneSingleFlashFrom" translate="yes" xml:space="preserve">
           <source>One single flash from</source>
-          <target state="new">One single flash from</target>
+          <target state="needs-review">Одна единственная световая от</target>
           <note from="MultilingualBuild" annotates="source" priority="2">used for heatmap flashbang tooltip</note>
         </trans-unit>
         <trans-unit id="ToolTipRemovePlayersFromWhitelist" translate="yes" xml:space="preserve">
           <source>Remove player(s) from whitelist (DEL)</source>
-          <target state="new">Remove player(s) from whitelist (DEL)</target>
+          <target state="needs-review">Удалить игроков из белого списка (DEL)</target>
         </trans-unit>
         <trans-unit id="ToolTipSeconds" translate="yes" xml:space="preserve">
           <source>second(s)</source>
-          <target state="new">second(s)</target>
+          <target state="needs-review">секунд(ы)</target>
           <note from="MultilingualBuild" annotates="source" priority="2">used for heatmap flashbang tooltip</note>
         </trans-unit>
         <trans-unit id="ToolTipSecondsOnAverage" translate="yes" xml:space="preserve">
           <source>second(s) on average</source>
-          <target state="new">second(s) on average</target>
+          <target state="needs-review">секунд(ы) в среднем</target>
           <note from="MultilingualBuild" annotates="source" priority="2">used for heatmap flashbang tooltip</note>
         </trans-unit>
         <trans-unit id="ToolTipShowPlayerDemos" translate="yes" xml:space="preserve">
           <source>Show demos that contains the player (CTRL+F)</source>
-          <target state="new">Show demos that contains the player (CTRL+F)</target>
+          <target state="needs-review">Показать демки, содержащие игрока (CTRL+F)</target>
         </trans-unit>
         <trans-unit id="ToolTipTimes" translate="yes" xml:space="preserve">
           <source>time(s)</source>
-          <target state="new">time(s)</target>
+          <target state="needs-review">время(с)</target>
           <note from="MultilingualBuild" annotates="source" priority="2">used for heatmap flashbang tooltip</note>
         </trans-unit>
         <trans-unit id="WhitelistInformation" translate="yes" xml:space="preserve">
           <source>Players listed below will not be checked for ban when analyzing a demo.</source>
-          <target state="new">Players listed below will not be checked for ban when analyzing a demo.</target>
+          <target state="needs-review">Нижеперечисленные игроки не будут проверяться на бан при анализе демки.</target>
         </trans-unit>
         <trans-unit id="All" translate="yes" xml:space="preserve">
           <source>All</source>
-          <target state="new">All</target>
+          <target state="needs-review">Все</target>
         </trans-unit>
         <trans-unit id="AllPlayers" translate="yes" xml:space="preserve">
           <source>All players</source>
-          <target state="new">All players</target>
+          <target state="needs-review">Все игроки</target>
         </trans-unit>
         <trans-unit id="AllRounds" translate="yes" xml:space="preserve">
           <source>All rounds</source>
-          <target state="new">All rounds</target>
+          <target state="needs-review">Все раунды</target>
         </trans-unit>
         <trans-unit id="AmountDollar" translate="yes" xml:space="preserve">
           <source>Amount ($)</source>
-          <target state="new">Amount ($)</target>
+          <target state="needs-review">Сумма ($)</target>
         </trans-unit>
         <trans-unit id="Chest" translate="yes" xml:space="preserve">
           <source>Chest</source>
-          <target state="new">Chest</target>
+          <target state="needs-review">Плечо</target>
         </trans-unit>
         <trans-unit id="Clear" translate="yes" xml:space="preserve">
           <source>Clear</source>
-          <target state="new">Clear</target>
+          <target state="needs-review">Очистить</target>
         </trans-unit>
         <trans-unit id="CopySetpos" translate="yes" xml:space="preserve">
           <source>Copy setpos</source>
-          <target state="new">Copy setpos</target>
+          <target state="needs-review">Скопировать setpos</target>
         </trans-unit>
         <trans-unit id="FlashedPlayers" translate="yes" xml:space="preserve">
           <source>Flashed players</source>
-          <target state="new">Flashed players</target>
+          <target state="needs-review">Ослепленные игроки</target>
         </trans-unit>
         <trans-unit id="Generate" translate="yes" xml:space="preserve">
           <source>Generate</source>
-          <target state="new">Generate</target>
+          <target state="needs-review">Сгенерировать</target>
         </trans-unit>
         <trans-unit id="Head" translate="yes" xml:space="preserve">
           <source>Head</source>
-          <target state="new">Head</target>
+          <target state="needs-review">Голова</target>
         </trans-unit>
         <trans-unit id="HeaderFlasherFlashed" translate="yes" xml:space="preserve">
           <source>Flasher \ Flashed</source>
-          <target state="new">Flasher \ Flashed</target>
+          <target state="needs-review">Ослепивший \ Ослепленный</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Used for flashbangs heatmap chart</note>
         </trans-unit>
         <trans-unit id="HeaderPlayerName" translate="yes" xml:space="preserve">
           <source>Player name</source>
-          <target state="new">Player name</target>
+          <target state="needs-review">Имя игрока</target>
         </trans-unit>
         <trans-unit id="HeaderTeamName" translate="yes" xml:space="preserve">
           <source>Team name</source>
-          <target state="new">Team name</target>
+          <target state="needs-review">Имя команды</target>
         </trans-unit>
         <trans-unit id="HeaderThrower" translate="yes" xml:space="preserve">
           <source>Thrower</source>
-          <target state="new">Thrower</target>
+          <target state="needs-review">Бросающий</target>
         </trans-unit>
         <trans-unit id="KillsPerRoundFull" translate="yes" xml:space="preserve">
           <source>KPR (Kills Per Round)</source>
-          <target state="new">KPR (Kills Per Round)</target>
+          <target state="needs-review">УЗР (Убийств за Раунд)</target>
         </trans-unit>
         <trans-unit id="LeftArm" translate="yes" xml:space="preserve">
           <source>Left arm</source>
-          <target state="new">Left arm</target>
+          <target state="needs-review">Левая рука</target>
         </trans-unit>
         <trans-unit id="LeftLeg" translate="yes" xml:space="preserve">
           <source>Left leg</source>
-          <target state="new">Left leg</target>
+          <target state="needs-review">Левая нога</target>
         </trans-unit>
         <trans-unit id="NotificationGenerating" translate="yes" xml:space="preserve">
           <source>Generating...</source>
-          <target state="new">Generating...</target>
+          <target state="needs-review">Генерация...</target>
         </trans-unit>
         <trans-unit id="NotificationUpdating" translate="yes" xml:space="preserve">
           <source>Updating...</source>
-          <target state="new">Updating...</target>
+          <target state="needs-review">Обновление...</target>
         </trans-unit>
         <trans-unit id="Opacity" translate="yes" xml:space="preserve">
           <source>Opacity</source>
-          <target state="new">Opacity</target>
+          <target state="needs-review">Непрозрачность</target>
         </trans-unit>
         <trans-unit id="RightArm" translate="yes" xml:space="preserve">
           <source>Right arm</source>
-          <target state="new">Right arm</target>
+          <target state="needs-review">Правая рука</target>
         </trans-unit>
         <trans-unit id="RightLeg" translate="yes" xml:space="preserve">
           <source>Right leg</source>
-          <target state="new">Right leg</target>
+          <target state="needs-review">Правая нога</target>
         </trans-unit>
         <trans-unit id="Sides" translate="yes" xml:space="preserve">
           <source>Sides</source>
-          <target state="new">Sides</target>
+          <target state="needs-review">Стороны</target>
         </trans-unit>
         <trans-unit id="Stomach" translate="yes" xml:space="preserve">
           <source>Stomach</source>
-          <target state="new">Stomach</target>
+          <target state="needs-review">Живот</target>
         </trans-unit>
         <trans-unit id="Team" translate="yes" xml:space="preserve">
           <source>Team</source>
-          <target state="new">Team</target>
+          <target state="needs-review">Команда</target>
         </trans-unit>
         <trans-unit id="ToolTipCopySetposCommand" translate="yes" xml:space="preserve">
           <source>Copy setpos command (CTRL+C)</source>
-          <target state="new">Copy setpos command (CTRL+C)</target>
+          <target state="needs-review">Скопировать команду setpos (CTRL+C)</target>
         </trans-unit>
         <trans-unit id="ToolTipGenerateHeatmap" translate="yes" xml:space="preserve">
           <source>Generate heatmap (CTRL+G)</source>
-          <target state="new">Generate heatmap (CTRL+G)</target>
+          <target state="needs-review">Сгенерировать тепловую карту (CTRL+G)</target>
         </trans-unit>
         <trans-unit id="ToolTipSaveAsPng" translate="yes" xml:space="preserve">
           <source>Save as PNG (CTRL+S)</source>
-          <target state="new">Save as PNG (CTRL+S)</target>
+          <target state="needs-review">Сохранить как PNG (CTRL+S)</target>
         </trans-unit>
         <trans-unit id="ToolTipUpdate" translate="yes" xml:space="preserve">
           <source>Update (CTRL+R)</source>
-          <target state="new">Update (CTRL+R)</target>
+          <target state="needs-review">Обновить (CTRL+R)</target>
         </trans-unit>
         <trans-unit id="ToolTipWatchAllStuffsFromPlayer" translate="yes" xml:space="preserve">
           <source>Watch all stuffs from this player (CTRL+W)</source>
-          <target state="new">Watch all stuffs from this player (CTRL+W)</target>
+          <target state="needs-review">Посмотреть все гранаты этого игрока (CTRL+W)</target>
         </trans-unit>
         <trans-unit id="TotalCashEarned" translate="yes" xml:space="preserve">
           <source>Total Cash Earned ($)</source>
-          <target state="new">Total Cash Earned ($)</target>
+          <target state="needs-review">Всего Денег Получено ($)</target>
         </trans-unit>
         <trans-unit id="TotalFlashbangsThrown" translate="yes" xml:space="preserve">
           <source>Total flashbang thrown</source>
-          <target state="new">Total flashbang thrown</target>
+          <target state="needs-review">Всего световых брошено</target>
         </trans-unit>
         <trans-unit id="Update" translate="yes" xml:space="preserve">
           <source>Update</source>
-          <target state="new">Update</target>
+          <target state="needs-review">Обновить</target>
         </trans-unit>
         <trans-unit id="WatchPlayerStuffs" translate="yes" xml:space="preserve">
           <source>Watch player stuffs</source>
-          <target state="new">Watch player stuffs</target>
+          <target state="needs-review">Посмотреть гранаты игрока</target>
         </trans-unit>
         <trans-unit id="DescriptionEntryHoldKills" translate="yes" xml:space="preserve">
           <source>(First kill by a CT)</source>
-          <target state="new">(First kill by a CT)</target>
+          <target state="needs-review">(Первое убийство за КТ)</target>
         </trans-unit>
         <trans-unit id="DescriptionEntryKills" translate="yes" xml:space="preserve">
           <source>(First kill by a T)</source>
-          <target state="new">(First kill by a T)</target>
+          <target state="needs-review">(Первое убийство за Т)</target>
         </trans-unit>
         <trans-unit id="HeaderMatrixKillerVictim" translate="yes" xml:space="preserve">
           <source>Killer \ Victim</source>
-          <target state="new">Killer \ Victim</target>
+          <target state="needs-review">Убийца \ Жертва</target>
         </trans-unit>
         <trans-unit id="HeaderRoundLost" translate="yes" xml:space="preserve">
           <source>RL</source>
-          <target state="new">RL</target>
+          <target state="needs-review">РП</target>
         </trans-unit>
         <trans-unit id="Matrix" translate="yes" xml:space="preserve">
           <source>Matrix</source>
-          <target state="new">Matrix</target>
+          <target state="needs-review">Матрица</target>
         </trans-unit>
         <trans-unit id="Ratio" translate="yes" xml:space="preserve">
           <source>Ratio</source>
-          <target state="new">Ratio</target>
+          <target state="needs-review">Соотношение</target>
         </trans-unit>
         <trans-unit id="Teams" translate="yes" xml:space="preserve">
           <source>Teams</source>
-          <target state="new">Teams</target>
+          <target state="needs-review">Команды</target>
         </trans-unit>
         <trans-unit id="Language" translate="yes" xml:space="preserve">
           <source>Language</source>
-          <target state="new">Language</target>
+          <target state="needs-review">Язык</target>
         </trans-unit>
         <trans-unit id="UnexpectedErrorOccured" translate="yes" xml:space="preserve">
           <source>An unexpected error occured. Please send the 'errors.log' file accessible from settings.
 Message Error :
 {0}</source>
-          <target state="new">An unexpected error occured. Please send the 'errors.log' file accessible from settings.
-Message Error :
+          <target state="needs-review">Возникла непредвиденная ошибка. Пожалуйста отправьте доступный в настройках файл 'errors.log'.
+Сообщение об Ошибке :
 {0}</target>
         </trans-unit>
         <trans-unit id="InformationTranslateIncomplete" translate="yes" xml:space="preserve">
           <source>If the app is still in english after changing the language, it means that the translation has not been done or is incomplete.</source>
-          <target state="new">If the app is still in english after changing the language, it means that the translation has not been done or is incomplete.</target>
+          <target state="needs-review">Если приложение всё еще на английском после смены языка, значит, перевод не выполнен или еще не закончен</target>
         </trans-unit>
         <trans-unit id="InfomationHelpTranslatingApp" translate="yes" xml:space="preserve">
           <source>You are free to help translating the app, more information on</source>
-          <target state="new">You are free to help translating the app, more information on</target>
+          <target state="needs-review">Вы можете помочь в переводе приложения, больше информации на</target>
         </trans-unit>
         <trans-unit id="Contributors" translate="yes" xml:space="preserve">
           <source>Contributors</source>
-          <target state="new">Contributors</target>
+          <target state="needs-review">Разработчики</target>
         </trans-unit>
         <trans-unit id="Translators" translate="yes" xml:space="preserve">
           <source>Translators</source>
-          <target state="new">Translators</target>
+          <target state="needs-review">Переводчики</target>
         </trans-unit>
         <trans-unit id="Banned" translate="yes" xml:space="preserve">
           <source>Banned</source>
-          <target state="new">Banned</target>
+          <target state="needs-review">Забанен</target>
         </trans-unit>
         <trans-unit id="Probation" translate="yes" xml:space="preserve">
           <source>Probation</source>
-          <target state="new">Probation</target>
+          <target state="needs-review">Стажировка</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTotalMatchesTime" translate="yes" xml:space="preserve">
           <source>Total Matches Time (hours / minutes)</source>
-          <target state="new">Total Matches Time (hours / minutes)</target>
+          <target state="needs-review">Общее Время Матчей (часы / минуты)</target>
         </trans-unit>
         <trans-unit id="HeaderTotalMatchesTime" translate="yes" xml:space="preserve">
           <source>TMT</source>
-          <target state="new">TMT</target>
+          <target state="needs-review">ОВМ</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Total Match Time</note>
         </trans-unit>
         <trans-unit id="HeaderAverageMatchTime" translate="yes" xml:space="preserve">
           <source>AMT</source>
-          <target state="new">AMT</target>
+          <target state="needs-review">СВМ</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Average Match Time</note>
         </trans-unit>
         <trans-unit id="HeaderToolTipAverageMatchTime" translate="yes" xml:space="preserve">
           <source>Average Match Time (minutes)</source>
-          <target state="new">Average Match Time (minutes)</target>
+          <target state="needs-review">Average Match Time (minutes)</target>
         </trans-unit>
         <trans-unit id="TotalMatchTimeValue" translate="yes" xml:space="preserve">
           <source>{0}h {1}m</source>
-          <target state="new">{0}h {1}m</target>
+          <target state="needs-review">{0}ч {1}м</target>
         </trans-unit>
         <trans-unit id="AverageMatchTimeValue" translate="yes" xml:space="preserve">
           <source>{0} minutes</source>
-          <target state="new">{0} minutes</target>
+          <target state="needs-review">{0} минут</target>
         </trans-unit>
         <trans-unit id="ToolTipExportChat" translate="yes" xml:space="preserve">
           <source>Export demo chat</source>
-          <target state="new">Export demo chat</target>
+          <target state="needs-review">Выгрузить чат демки"</target>
         </trans-unit>
         <trans-unit id="ExportChat" translate="yes" xml:space="preserve">
           <source>Export chat</source>
-          <target state="new">Export chat</target>
+          <target state="needs-review">Выгрузить чат</target>
         </trans-unit>
         <trans-unit id="NoHeatmapDataFound" translate="yes" xml:space="preserve">
           <source>No {0} found for this selection.</source>
-          <target state="new">No {0} found for this selection.</target>
+          <target state="needs-review">{0} не найдено в этой выборке.</target>
         </trans-unit>
         <trans-unit id="Shots" translate="yes" xml:space="preserve">
           <source>Shots</source>
-          <target state="new">Shots</target>
+          <target state="needs-review">Выстрелы</target>
         </trans-unit>
         <trans-unit id="DialogDemoShareCodeUnavailable" translate="yes" xml:space="preserve">
           <source>This demo is not from Valve matchmaking servers or the .info file is missing.</source>
-          <target state="new">This demo is not from Valve matchmaking servers or the .info file is missing.</target>
+          <target state="needs-review">Эта демка не с ММ серверов Valve или файл .info отсутствует.</target>
         </trans-unit>
         <trans-unit id="CopyDemoShareCode" translate="yes" xml:space="preserve">
           <source>Copy share code</source>
-          <target state="new">Copy share code</target>
+          <target state="needs-review">Скопировать общий код</target>
         </trans-unit>
         <trans-unit id="ShowOnThirdParty" translate="yes" xml:space="preserve">
           <source>Show on third party application</source>
-          <target state="new">Show on third party application</target>
+          <target state="needs-review">Показать в стороннем приложении</target>
         </trans-unit>
         <trans-unit id="DialogShareCodeNotAvailable" translate="yes" xml:space="preserve">
           <source>Share code not available. It works only with demos from Valve matchmaking servers and if the .info file exists.</source>
-          <target state="new">Share code not available. It works only with demos from Valve matchmaking servers and if the .info file exists.</target>
+          <target state="needs-review">Общий код недоступен. Это работает только с демками с ММ серверов Valve и если файл .info существует.</target>
         </trans-unit>
         <trans-unit id="YesDontAsk" translate="yes" xml:space="preserve">
           <source>Yes and don't ask next time</source>
-          <target state="new">Yes and don't ask next time</target>
+          <target state="needs-review">Да и не спрашивать в следующий раз</target>
         </trans-unit>
         <trans-unit id="DialogSendThirdPartyConfirmation" translate="yes" xml:space="preserve">
           <source>You are going to send the demo's share code to {0}. Do you want to continue?</source>
-          <target state="new">You are going to send the demo's share code to {0}. Do you want to continue?</target>
+          <target state="needs-review">Вы собираетесь отправить общий код на {0}. Хотите продолжить?</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileSendingShareCode" translate="yes" xml:space="preserve">
           <source>An error occured while sending the share code.</source>
-          <target state="new">An error occured while sending the share code.</target>
+          <target state="needs-review">Возникла ошибка при отправке общего кода.</target>
         </trans-unit>
         <trans-unit id="DialogSendShareCodeWarning" translate="yes" xml:space="preserve">
           <source>You are going to send the demo's share code to {0}.</source>
-          <target state="new">You are going to send the demo's share code to {0}.</target>
+          <target state="needs-review">Вы собираетесь отправить общий код демки на {0}.</target>
         </trans-unit>
         <trans-unit id="DialogSelectThirdParty" translate="yes" xml:space="preserve">
           <source>Select third party application</source>
-          <target state="new">Select third party application</target>
+          <target state="needs-review">Выберете стороннее приложение</target>
         </trans-unit>
         <trans-unit id="ToolTipShowDemoOnThirdParty" translate="yes" xml:space="preserve">
           <source>Show demo's details on a third party application</source>
-          <target state="new">Show demo's details on a third party application</target>
+          <target state="needs-review">Показать подробности демки в стороннем приложении</target>
         </trans-unit>
         <trans-unit id="DialogConfigurationCorrupted" translate="yes" xml:space="preserve">
           <source>Your configuration file is corrupted. Please restart the application to reset your configuration.</source>
-          <target state="new">Your configuration file is corrupted. Please restart the application to reset your configuration.</target>
+          <target state="needs-review">Ваша конфигурация повреждена. Пожалуйста перезагрузите приложение, чтобы сбросить вашу конфигурацию.</target>
         </trans-unit>
         <trans-unit id="EnableMovieMakingConfigParentFolder" translate="yes" xml:space="preserve">
           <source>Enable movie making config parent folder</source>
-          <target state="new">Enable movie making config parent folder</target>
+          <target state="needs-review">Включить родительскую папку конфига видеоредактора</target>
         </trans-unit>
         <trans-unit id="EnableHlae" translate="yes" xml:space="preserve">
           <source>Enable HLAE</source>
-          <target state="new">Enable HLAE</target>
+          <target state="needs-review">Включить HLAE</target>
         </trans-unit>
         <trans-unit id="DialogEnableHlaeWarning" translate="yes" xml:space="preserve">
           <source>Enabling HLAE change the way the game is started (when you click on all "Watch" buttons).
@@ -3390,941 +3390,941 @@ It will use the tool "Half-Life Advanced Effects" (HLAE) which is technically a 
 You should use it ONLY if you know what you are doing AND to make moviemaking related stuff.
 If you don't know what is this or you are not planning to make movies just click on cancel.
 If you enable it, the game is launched with the "-insecure" parameter (everytime), which means that you will not be able to join server protected by VAC and prevent from a VAC ban.</source>
-          <target state="new">Enabling HLAE change the way the game is started (when you click on all "Watch" buttons).
-It will use the tool "Half-Life Advanced Effects" (HLAE) which is technically a hack.
-You should use it ONLY if you know what you are doing AND to make moviemaking related stuff.
-If you don't know what is this or you are not planning to make movies just click on cancel.
-If you enable it, the game is launched with the "-insecure" parameter (everytime), which means that you will not be able to join server protected by VAC and prevent from a VAC ban.</target>
+          <target state="needs-review">Включение HLAE меняет способ запуска игры (при нажатии на все кнопки "Смотреть").
+Он будет использовать инструмент Half-Life Advanced Effects (HLAE), который технически является хаком.
+Вы должны использовать его, ТОЛЬКО если вы знаете, что делаете, И делать вещи, связанные с видеопроизводством.
+Если вы не знаете, что это такое, или не планируете снимать видео, просто нажмите «Отмена».
+Если его включить, то игра (всегда) запускается с параметром "-insecure", что означает, что вы не сможете присоединиться к серверу, защищенному VAC, и не получите VAC-бан.</target>
         </trans-unit>
         <trans-unit id="DialogHlaeNotFound" translate="yes" xml:space="preserve">
           <source>It looks like HLAE isn't installed.
 Do you want to install it? (If you are using it you have to install it first to be able to use it)</source>
-          <target state="new">It looks like HLAE isn't installed.
-Do you want to install it? (If you are using it you have to install it first to be able to use it)</target>
+          <target state="needs-review">Похоже, HLAE не установлен.
+Вы хотите установить его? (Если вы используете его, вы должны сначала установить его, чтобы иметь возможность использовать его)</target>
         </trans-unit>
         <trans-unit id="DialogNewHlaeVersionAvailable" translate="yes" xml:space="preserve">
           <source>A new HLAE version is avalailable.
 Do you want to install it? (It's recommended to avoid possible crash due to CSGO updates)</source>
-          <target state="new">A new HLAE version is avalailable.
-Do you want to install it? (It's recommended to avoid possible crash due to CSGO updates)</target>
+          <target state="needs-review">Доступна новая версия HLAE.
+Вы хотите установить её? (Рекомендуется, чтобы избежать возможного сбоя из-за обновлений CSGO)</target>
         </trans-unit>
         <trans-unit id="DialogHlaeInstallationFailed" translate="yes" xml:space="preserve">
           <source>An error occured while installing HLAE.</source>
-          <target state="new">An error occured while installing HLAE.</target>
+          <target state="needs-review">Возникла ошибка при установке HLAE.</target>
         </trans-unit>
         <trans-unit id="DialogHlaeInstalled" translate="yes" xml:space="preserve">
           <source>HLAE has been installed.</source>
-          <target state="new">HLAE has been installed.</target>
+          <target state="needs-review">HLAE был установлен.</target>
         </trans-unit>
         <trans-unit id="DialogHlaeRequired" translate="yes" xml:space="preserve">
           <source>HLAE needs to be installed to use it.</source>
-          <target state="new">HLAE needs to be installed to use it.</target>
+          <target state="needs-review">HLAE должен быть установлен, чтобы использовать его.</target>
         </trans-unit>
         <trans-unit id="DialogHlaeUpdated" translate="yes" xml:space="preserve">
           <source>HLAE has been updated.</source>
-          <target state="new">HLAE has been updated.</target>
+          <target state="needs-review">HLAE был обновлён.</target>
         </trans-unit>
         <trans-unit id="DialogHlaeUpdateFailed" translate="yes" xml:space="preserve">
           <source>An error occured while updating HLAE.</source>
-          <target state="new">An error occured while updating HLAE.</target>
+          <target state="needs-review">Возникла ошибка при обновлении HLAE.</target>
         </trans-unit>
         <trans-unit id="NotificationInstallingHlae" translate="yes" xml:space="preserve">
           <source>Installing HLAE...</source>
-          <target state="new">Installing HLAE...</target>
+          <target state="needs-review">Установка HLAE...</target>
         </trans-unit>
         <trans-unit id="NotificationUpdatingHlae" translate="yes" xml:space="preserve">
           <source>Updating HLAE...</source>
-          <target state="new">Updating HLAE...</target>
+          <target state="needs-review">Обновление HLAE...</target>
         </trans-unit>
         <trans-unit id="DialogPlayerFocusedNotFound" translate="yes" xml:space="preserve">
           <source>The player that you are focusing is not in this demo. You can change it from settings (accounts section) or watch it from the scoreboard.</source>
-          <target state="new">The player that you are focusing is not in this demo. You can change it from settings (accounts section) or watch it from the scoreboard.</target>
+          <target state="needs-review">Игрок, на котором вы фокусируетесь, отсутствует в этой демке. Вы можете изменить его в настройках (раздел аккаунтов) или посмотреть на табло.</target>
         </trans-unit>
         <trans-unit id="DemosListSize" translate="yes" xml:space="preserve">
           <source>Demos list size</source>
-          <target state="new">Demos list size</target>
+          <target state="needs-review">Размер списка демок</target>
         </trans-unit>
         <trans-unit id="ShowAllDemos" translate="yes" xml:space="preserve">
           <source>Show all demos</source>
-          <target state="new">Show all demos</target>
+          <target state="needs-review">Показать все демки</target>
         </trans-unit>
         <trans-unit id="DialogErrorInvalidShareCode" translate="yes" xml:space="preserve">
           <source>Invalid share code</source>
-          <target state="new">Invalid share code</target>
+          <target state="needs-review">Неверный общий код</target>
         </trans-unit>
         <trans-unit id="ToolTipDownloadDemoFromShareCode" translate="yes" xml:space="preserve">
           <source>Download a demo from share code</source>
-          <target state="new">Download a demo from share code</target>
+          <target state="needs-review">Скачать демо по общему коду</target>
         </trans-unit>
         <trans-unit id="ShareCode" translate="yes" xml:space="preserve">
           <source>Share code</source>
-          <target state="new">Share code</target>
+          <target state="needs-review">Общий код</target>
         </trans-unit>
         <trans-unit id="DialogMessageDownloadDemoFromShareCode" translate="yes" xml:space="preserve">
           <source>You are going to download a demo from its share code.
 
 Please enter the share code (example: CSGO-orkmt-Z8udN-apVEh-GQtx3-sU7CR).</source>
-          <target state="new">You are going to download a demo from its share code.
+          <target state="needs-review">Вы собираетесь скачать демку по общему коду.
 
-Please enter the share code (example: CSGO-orkmt-Z8udN-apVEh-GQtx3-sU7CR).</target>
+Пожалуйста введите общий код (пример: CSGO-orkmt-Z8udN-apVEh-GQtx3-sU7CR).</target>
         </trans-unit>
         <trans-unit id="DialogTitleDownloadDemoFromShareCode" translate="yes" xml:space="preserve">
           <source>Download demo from share code</source>
-          <target state="new">Download demo from share code</target>
+          <target state="needs-review">Скачать демо по общему коду</target>
         </trans-unit>
         <trans-unit id="DialogDemoFromShareCodeNotAvailable" translate="yes" xml:space="preserve">
           <source>Demo link has expired or you already have it in your download folder.</source>
-          <target state="new">Demo link has expired or you already have it in your download folder.</target>
+          <target state="needs-review">Срок действия ссылки на демку истёк или она уже находится в вашей папке закачек.</target>
         </trans-unit>
         <trans-unit id="NotificationRetrievingDemoFromShareCode" translate="yes" xml:space="preserve">
           <source>Retrieving demo data...</source>
-          <target state="new">Retrieving demo data...</target>
+          <target state="needs-review">Получение информации демки...</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileRetrievingDemoData" translate="yes" xml:space="preserve">
           <source>An error occured while retrieving demo data.</source>
-          <target state="new">An error occured while retrieving demo data.</target>
+          <target state="needs-review">Возникла ошибка при получении данных демки.</target>
         </trans-unit>
         <trans-unit id="HeaderEseaRws" translate="yes" xml:space="preserve">
           <source>RWS</source>
-          <target state="new">RWS</target>
+          <target state="needs-review">ВПР</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipEseaRws" translate="yes" xml:space="preserve">
           <source>Average ESEA Round Win Share</source>
-          <target state="new">Average ESEA Round Win Share</target>
+          <target state="needs-review">Средний ESEA Вклад в Победу в Раунде</target>
         </trans-unit>
         <trans-unit id="HeaderAccuracy" translate="yes" xml:space="preserve">
           <source>ACC (%)</source>
-          <target state="new">ACC (%)</target>
+          <target state="needs-review">ТОЧ (%)</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipAccuracy" translate="yes" xml:space="preserve">
           <source>Accuracy (%)</source>
-          <target state="new">Accuracy (%)</target>
+          <target state="needs-review">Точность (%)</target>
         </trans-unit>
         <trans-unit id="Accuracy" translate="yes" xml:space="preserve">
           <source>Accuracy</source>
-          <target state="new">Accuracy</target>
+          <target state="needs-review">Точность</target>
         </trans-unit>
         <trans-unit id="AccuracyFull" translate="yes" xml:space="preserve">
           <source>Accuracy % (shots / hits)</source>
-          <target state="new">Accuracy % (shots / hits)</target>
+          <target state="needs-review">Точность % (попаданий / выстрелов)</target>
         </trans-unit>
         <trans-unit id="Hits" translate="yes" xml:space="preserve">
           <source>Hits</source>
-          <target state="new">Hits</target>
+          <target state="needs-review">Попаданий</target>
         </trans-unit>
         <trans-unit id="NotificationImportingCustomData" translate="yes" xml:space="preserve">
           <source>Importing custom data...</source>
-          <target state="new">Importing custom data...</target>
+          <target state="needs-review">Импорт выборочных данных...</target>
         </trans-unit>
         <trans-unit id="HeaderTimeDeath" translate="yes" xml:space="preserve">
           <source>TD (s)</source>
-          <target state="new">TD (s)</target>
+          <target state="needs-review">ВрС (с)</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipTimeDeath" translate="yes" xml:space="preserve">
           <source>Time Death (seconds)</source>
-          <target state="new">Time Death (seconds)</target>
+          <target state="needs-review">Время Смерти (секунд)</target>
         </trans-unit>
         <trans-unit id="AverageTimeDeath" translate="yes" xml:space="preserve">
           <source>Average Time Death (s)</source>
-          <target state="new">Average Time Death (s)</target>
+          <target state="needs-review">Среднее Время Смерти (с)</target>
         </trans-unit>
         <trans-unit id="AverageTimeDeathFull" translate="yes" xml:space="preserve">
           <source>Average time the player died in seconds after the freezetime ended</source>
-          <target state="new">Average time the player died in seconds after the freezetime ended</target>
+          <target state="needs-review">Среднее время, через которое умирает игрок, в секундах после начала раунда</target>
         </trans-unit>
         <trans-unit id="HeaderAverageTimeDeath" translate="yes" xml:space="preserve">
           <source>ATD (s)</source>
-          <target state="new">ATD (s)</target>
+          <target state="needs-review">СВрС (с)</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipAverageTimeDeath" translate="yes" xml:space="preserve">
           <source>Average Time Death (seconds)</source>
-          <target state="new">Average Time Death (seconds)</target>
+          <target state="needs-review">Среднее Время Смерти (секунд)</target>
         </trans-unit>
         <trans-unit id="ToolTipSaveAsPngNoShortcut" translate="yes" xml:space="preserve">
           <source>Save as PNG</source>
-          <target state="new">Save as PNG</target>
+          <target state="needs-review">Сохранить как PNG</target>
         </trans-unit>
         <trans-unit id="DialogErrorExportingChart" translate="yes" xml:space="preserve">
           <source>An error occured while exporting the chart.</source>
-          <target state="new">An error occured while exporting the chart.</target>
+          <target state="needs-review">Возникла ошибка при экспорте чарта.</target>
         </trans-unit>
         <trans-unit id="DemoStatusCorrupted" translate="yes" xml:space="preserve">
           <source>Corrupted</source>
-          <target state="new">Corrupted</target>
+          <target state="needs-review">Повреждёна</target>
         </trans-unit>
         <trans-unit id="DemoStatusError" translate="yes" xml:space="preserve">
           <source>Error</source>
-          <target state="new">Error</target>
+          <target state="needs-review">Ошибка</target>
         </trans-unit>
         <trans-unit id="DemoStatusNone" translate="yes" xml:space="preserve">
           <source>None</source>
-          <target state="new">None</target>
+          <target state="needs-review">Нет</target>
         </trans-unit>
         <trans-unit id="DemoStatusToWatch" translate="yes" xml:space="preserve">
           <source>To watch</source>
-          <target state="new">To watch</target>
+          <target state="needs-review">К просмотру</target>
         </trans-unit>
         <trans-unit id="DemoStatusWatched" translate="yes" xml:space="preserve">
           <source>Watched</source>
-          <target state="new">Watched</target>
+          <target state="needs-review">Просмотрена</target>
         </trans-unit>
         <trans-unit id="DialogDemosCorruptedWarning" translate="yes" xml:space="preserve">
           <source>The following demos are corrupted:
 {0}
 You may have missing data for this demos.</source>
-          <target state="new">The following demos are corrupted:
+          <target state="needs-review">Следующие демки повреждены:
 {0}
-You may have missing data for this demos.</target>
+Возможно, у вас отсутствуют данные для этих демок.</target>
         </trans-unit>
         <trans-unit id="UseSimpleRadarCheckbox" translate="yes" xml:space="preserve">
           <source>Use Simple Radar overviews</source>
-          <target state="new">Use Simple Radar overviews</target>
+          <target state="needs-review">Использовать карты Simple Radar</target>
         </trans-unit>
         <trans-unit id="SecondsRound" translate="yes" xml:space="preserve">
           <source>Seconds (R)</source>
-          <target state="new">Seconds (R)</target>
+          <target state="needs-review">Секунд (Р)</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipSecondsRoundStuffThrown" translate="yes" xml:space="preserve">
           <source>Seconds elapsed since the round's freezetime ended</source>
-          <target state="new">Seconds elapsed since the round's freezetime ended</target>
+          <target state="needs-review">Секунд прошло с момента начала раунда</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipSecondsDemoStuffThrown" translate="yes" xml:space="preserve">
           <source>Seconds elapsed since the beginning of the demo</source>
-          <target state="new">Seconds elapsed since the beginning of the demo</target>
+          <target state="needs-review">Секунд прошло с момента начала демки</target>
         </trans-unit>
         <trans-unit id="SecondsDemo" translate="yes" xml:space="preserve">
           <source>Seconds (D)</source>
-          <target state="new">Seconds (D)</target>
+          <target state="needs-review">Секунд (Д)</target>
         </trans-unit>
         <trans-unit id="Decoy" translate="yes" xml:space="preserve">
           <source>Decoy</source>
-          <target state="new">Decoy</target>
+          <target state="needs-review">Отвлекающая граната</target>
         </trans-unit>
         <trans-unit id="Flashbang" translate="yes" xml:space="preserve">
           <source>Flashbang</source>
-          <target state="new">Flashbang</target>
+          <target state="needs-review">Световая граната</target>
         </trans-unit>
         <trans-unit id="HE" translate="yes" xml:space="preserve">
           <source>HE</source>
-          <target state="new">HE</target>
+          <target state="needs-review">БГ</target>
         </trans-unit>
         <trans-unit id="Incendiary" translate="yes" xml:space="preserve">
           <source>Incendiary</source>
-          <target state="new">Incendiary</target>
+          <target state="needs-review">Зажигательная граната</target>
         </trans-unit>
         <trans-unit id="Molotov" translate="yes" xml:space="preserve">
           <source>Molotov</source>
-          <target state="new">Molotov</target>
+          <target state="needs-review">Коктейль Молотова</target>
         </trans-unit>
         <trans-unit id="FocusOnPlayer" translate="yes" xml:space="preserve">
           <source>Focus on player</source>
-          <target state="new">Focus on player</target>
+          <target state="needs-review">Фокус на игроке</target>
         </trans-unit>
         <trans-unit id="FocusOnThrower" translate="yes" xml:space="preserve">
           <source>Focus on thrower</source>
-          <target state="new">Focus on thrower</target>
+          <target state="needs-review">Фокус на бросающем</target>
         </trans-unit>
         <trans-unit id="FocusOnVictim" translate="yes" xml:space="preserve">
           <source>Focus on victim</source>
-          <target state="new">Focus on victim</target>
+          <target state="needs-review">Фокус на жертве</target>
         </trans-unit>
         <trans-unit id="SetTickAsStartTick" translate="yes" xml:space="preserve">
           <source>Set tick {0} as start tick</source>
-          <target state="new">Set tick {0} as start tick</target>
+          <target state="needs-review">Установить тик {0} как начальный тик</target>
         </trans-unit>
         <trans-unit id="AnalyzeForTimeLineWarning" translate="yes" xml:space="preserve">
           <source>You have to analyze the demo first to have the timeline.</source>
-          <target state="new">You have to analyze the demo first to have the timeline.</target>
+          <target state="needs-review">Вы должны сначала проанализировать демку, чтобы иметь временную шкалу.</target>
         </trans-unit>
         <trans-unit id="AutoCloseGameOnRecordEnd" translate="yes" xml:space="preserve">
           <source>Auto close the game when recording is done</source>
-          <target state="new">Auto close the game when recording is done</target>
+          <target state="needs-review">Автоматически закрыть игру по окончании записи</target>
         </trans-unit>
         <trans-unit id="BombPlantedBy" translate="yes" xml:space="preserve">
           <source>the bomb planted by</source>
-          <target state="new">the bomb planted by</target>
+          <target state="needs-review">бомба установлена игроком</target>
         </trans-unit>
         <trans-unit id="CFG" translate="yes" xml:space="preserve">
           <source>CFG</source>
-          <target state="new">CFG</target>
+          <target state="needs-review">Конфиг</target>
         </trans-unit>
         <trans-unit id="Change" translate="yes" xml:space="preserve">
           <source>Change</source>
-          <target state="new">Change</target>
+          <target state="needs-review">Изменить</target>
         </trans-unit>
         <trans-unit id="ChangeHLAEParentFolderLocation" translate="yes" xml:space="preserve">
           <source>Change HLAE config parent folder location</source>
-          <target state="new">Change HLAE config parent folder location</target>
+          <target state="needs-review">Изменить расположение родительского каталога конфига HLAE</target>
         </trans-unit>
         <trans-unit id="CheckingForHLAEUpdate" translate="yes" xml:space="preserve">
           <source>Checking for HLAE update...</source>
-          <target state="new">Checking for HLAE update...</target>
+          <target state="needs-review">Проверка обновлений HLAE...</target>
         </trans-unit>
         <trans-unit id="CSGORecordingInProgress" translate="yes" xml:space="preserve">
           <source>CSGO in-game recording in progress, please wait...</source>
-          <target state="new">CSGO in-game recording in progress, please wait...</target>
+          <target state="needs-review">Внутриигровая запись CSGO в процессе, подождите...</target>
         </trans-unit>
         <trans-unit id="DefusedOnSite" translate="yes" xml:space="preserve">
           <source>defused the bomb on site</source>
-          <target state="new">defused the bomb on site</target>
+          <target state="needs-review">разминировал бомбу на точке</target>
         </trans-unit>
         <trans-unit id="DeleteRawFilesOnEncodeEnd" translate="yes" xml:space="preserve">
           <source>Delete raw files at the end of encoding</source>
-          <target state="new">Delete raw files at the end of encoding</target>
+          <target state="needs-review">Удалить исходные файлы по окончании кодирования</target>
         </trans-unit>
         <trans-unit id="DialogAmountSpaceRequired" translate="yes" xml:space="preserve">
           <source>You need about {0} GB available on your HDD.
 Do you want to continue?</source>
-          <target state="new">You need about {0} GB available on your HDD.
-Do you want to continue?</target>
+          <target state="needs-review">Вам понадобится около {0} ГБ на жестком диске.
+Хотите продолжить?</target>
         </trans-unit>
         <trans-unit id="DialogEndTickGreaterThanStartTick" translate="yes" xml:space="preserve">
           <source>End tick must be greater than start tick.</source>
-          <target state="new">End tick must be greater than start tick.</target>
+          <target state="needs-review">Конечный тик должен быть больше начального.</target>
         </trans-unit>
         <trans-unit id="DialogErrorInstallingFFmpeg" translate="yes" xml:space="preserve">
           <source>An error occured while installing FFmpeg.
 {0}</source>
-          <target state="new">An error occured while installing FFmpeg.
+          <target state="needs-review">Возникла ошибка при установке FFmpeg.
 {0}</target>
         </trans-unit>
         <trans-unit id="DialogErrorInstallingHLAE" translate="yes" xml:space="preserve">
           <source>An error occured while installing HLAE.
 {0}</source>
-          <target state="new">An error occured while installing HLAE.
+          <target state="needs-review">Возникла ошибка при установке HLAE.
 {0}</target>
         </trans-unit>
         <trans-unit id="DialogErrorInstallingVirtualDub" translate="yes" xml:space="preserve">
           <source>An error occured while installing VirtualDub.
 {0}</source>
-          <target state="new">An error occured while installing VirtualDub.
+          <target state="needs-review">Возникла ошибка при установке VirtualDub.
 {0}</target>
         </trans-unit>
         <trans-unit id="DialogErrorLoadingData" translate="yes" xml:space="preserve">
           <source>An error occured while loading data.
 {0}</source>
-          <target state="new">An error occured while loading data.
+          <target state="needs-review">Возникла ошибка при загрузке данных.
 {0}</target>
         </trans-unit>
         <trans-unit id="DialogErrorSavingCommentDemo" translate="yes" xml:space="preserve">
           <source>An error occured while saving hte comment of the demo</source>
-          <target state="new">An error occured while saving hte comment of the demo</target>
+          <target state="needs-review">Возникла ошибка при сохранении комментария к демке</target>
         </trans-unit>
         <trans-unit id="DialogErrorUpdatingHLAE" translate="yes" xml:space="preserve">
           <source>An error occured while updating HLAE.
 {0}</source>
-          <target state="new">An error occured while updating HLAE.
+          <target state="needs-review">Возникла ошибка при обновлении HLAE.
 {0}</target>
         </trans-unit>
         <trans-unit id="DialogErrorWhileGeneratingVideo" translate="yes" xml:space="preserve">
           <source>An error occured while generating the video.
 {0}</source>
-          <target state="new">An error occured while generating the video.
+          <target state="needs-review">Возникла ошибка при создании видео.
 {0}</target>
         </trans-unit>
         <trans-unit id="DialogFFmpegHasBeenInstalled" translate="yes" xml:space="preserve">
           <source>FFmpeg has been installed.</source>
-          <target state="new">FFmpeg has been installed.</target>
+          <target state="needs-review">FFmpeg установлен.</target>
         </trans-unit>
         <trans-unit id="DialogFFmpegHasNotInstalled" translate="yes" xml:space="preserve">
           <source>FFmpeg has not been installed.</source>
-          <target state="new">FFmpeg has not been installed.</target>
+          <target state="needs-review">FFmpeg не установлен.</target>
         </trans-unit>
         <trans-unit id="DialogHLAEHasBeenInstalled" translate="yes" xml:space="preserve">
           <source>HLAE has been installed.</source>
-          <target state="new">HLAE has been installed.</target>
+          <target state="needs-review">HLAE установлен.</target>
         </trans-unit>
         <trans-unit id="DialogHLAEHasBeenUpdated" translate="yes" xml:space="preserve">
           <source>HLAE has been updated.</source>
-          <target state="new">HLAE has been updated.</target>
+          <target state="needs-review">HLAE обновлён.</target>
         </trans-unit>
         <trans-unit id="DialogHLAEHasNotBeenInstalled" translate="yes" xml:space="preserve">
           <source>HLAE has not been installed.</source>
-          <target state="new">HLAE has not been installed.</target>
+          <target state="needs-review">HLAE не установлен.</target>
         </trans-unit>
         <trans-unit id="DialogHLAEHasNotBeenUpdated" translate="yes" xml:space="preserve">
           <source>HLAE has not been updated.</source>
-          <target state="new">HLAE has not been updated.</target>
+          <target state="needs-review">HLAE не обновлён.</target>
         </trans-unit>
         <trans-unit id="DialogInstallFFmpegFirst" translate="yes" xml:space="preserve">
           <source>Please install FFmpeg first from FFmpeg section.</source>
-          <target state="new">Please install FFmpeg first from FFmpeg section.</target>
+          <target state="needs-review">Пожалуйста сначала установите FFmpeg из раздела FFmpeg.</target>
         </trans-unit>
         <trans-unit id="DialogInstallHLAEFirst" translate="yes" xml:space="preserve">
           <source>Please install HLAE first from HLAE section.</source>
-          <target state="new">Please install HLAE first from HLAE section.</target>
+          <target state="needs-review">Пожалуйста сначала установите HLAE из раздела HLAE.</target>
         </trans-unit>
         <trans-unit id="DialogInstallVirtuaDubFirst" translate="yes" xml:space="preserve">
           <source>Please install VirtualDub first from VirtualDub section.</source>
-          <target state="new">Please install VirtualDub first from VirtualDub section.</target>
+          <target state="needs-review">Пожалуйста сначала установите VirtualDub из раздела VirtualDub.</target>
         </trans-unit>
         <trans-unit id="DialogPleaseUpdateHLAE" translate="yes" xml:space="preserve">
           <source>A new HLAE version is available.
 Please update it by clicking on the "Update" button.</source>
-          <target state="new">A new HLAE version is available.
-Please update it by clicking on the "Update" button.</target>
+          <target state="needs-review">Доступна новая версия HLAE.
+Пожалуйста обновите его, нажав кнопку "Обновить".</target>
         </trans-unit>
         <trans-unit id="DialogSelectCsgoExeLocation" translate="yes" xml:space="preserve">
           <source>Please select csgo.exe path from HLAE section.</source>
-          <target state="new">Please select csgo.exe path from HLAE section.</target>
+          <target state="needs-review">Пожалуйста укажите путь к файлу csgo.exe в разделе HLAE.</target>
         </trans-unit>
         <trans-unit id="DialogSelectRawFilesDestination" translate="yes" xml:space="preserve">
           <source>Please select a raw files folder destination.</source>
-          <target state="new">Please select a raw files folder destination.</target>
+          <target state="needs-review">Укажите папку исходных файлов.</target>
         </trans-unit>
         <trans-unit id="DialogSelectValidEndTick" translate="yes" xml:space="preserve">
           <source>Please select a valid end tick.</source>
-          <target state="new">Please select a valid end tick.</target>
+          <target state="needs-review">Укажите корректный конечный тик.</target>
         </trans-unit>
         <trans-unit id="DialogSelectValidStartTIck" translate="yes" xml:space="preserve">
           <source>Please select a valid start tick.</source>
-          <target state="new">Please select a valid start tick.</target>
+          <target state="needs-review">Укажите корректный начальный тик.</target>
         </trans-unit>
         <trans-unit id="DialogVirtualDubHasBeenInstalled" translate="yes" xml:space="preserve">
           <source>VirtualDub has been installed.</source>
-          <target state="new">VirtualDub has been installed.</target>
+          <target state="needs-review">VirtualDub установлен.</target>
         </trans-unit>
         <trans-unit id="DialogVirtualDubHasNotBeenInstalled" translate="yes" xml:space="preserve">
           <source>VirtualDub has not been installed.</source>
-          <target state="new">VirtualDub has not been installed.</target>
+          <target state="needs-review">VirtualDub не установлен.</target>
         </trans-unit>
         <trans-unit id="ExampleCFG" translate="yes" xml:space="preserve">
           <source>// CFG example with some useful commands
 // You should paste your moviemaking CFG here</source>
-          <target state="new">// CFG example with some useful commands
-// You should paste your moviemaking CFG here</target>
+          <target state="needs-review">// Пример конфига с полезными командами
+// Вставьте сюда свой конфиг для видеомонтажа</target>
         </trans-unit>
         <trans-unit id="ExplodedOnSite" translate="yes" xml:space="preserve">
           <source>exploded on site</source>
-          <target state="new">exploded on site</target>
+          <target state="needs-review">взорвана на точке</target>
         </trans-unit>
         <trans-unit id="FFmpegEncodingInProgress" translate="yes" xml:space="preserve">
           <source>FFmpeg encoding in progress, please wait...</source>
-          <target state="new">FFmpeg encoding in progress, please wait...</target>
+          <target state="needs-review">FFmpeg кодирование в процессе, подождите...</target>
         </trans-unit>
         <trans-unit id="FollowingCFGWillBeExecuted" translate="yes" xml:space="preserve">
           <source>The following CFG will be automatically executed:</source>
-          <target state="new">The following CFG will be automatically executed:</target>
+          <target state="needs-review">Следующий конфиг будет выполнен автоматически:</target>
         </trans-unit>
         <trans-unit id="FollowingCFGWillBeExecutedOnGameStart" translate="yes" xml:space="preserve">
           <source>The following CFG will be executed when the demo start playing:</source>
-          <target state="new">The following CFG will be executed when the demo start playing:</target>
+          <target state="needs-review">Следующий конфиг будет выполнен при воспроизведении демки:</target>
         </trans-unit>
         <trans-unit id="GB" translate="yes" xml:space="preserve">
           <source>GB</source>
-          <target state="new">GB</target>
+          <target state="needs-review">ГБ</target>
         </trans-unit>
         <trans-unit id="GenerateVideoFile" translate="yes" xml:space="preserve">
           <source>Generate video file</source>
-          <target state="new">Generate video file</target>
+          <target state="needs-review">Создать видеофайл</target>
         </trans-unit>
         <trans-unit id="HowManySeconds" translate="yes" xml:space="preserve">
           <source>How many seconds?</source>
-          <target state="new">How many seconds?</target>
+          <target state="needs-review">Сколько секунд?</target>
         </trans-unit>
         <trans-unit id="Install" translate="yes" xml:space="preserve">
           <source>Install</source>
-          <target state="new">Install</target>
+          <target state="needs-review">Установить</target>
         </trans-unit>
         <trans-unit id="InstallingVirtualDub" translate="yes" xml:space="preserve">
           <source>Installing VirtualDub...</source>
-          <target state="new">Installing VirtualDub...</target>
+          <target state="needs-review">Устанавливается VirtualDub...</target>
         </trans-unit>
         <trans-unit id="Killed" translate="yes" xml:space="preserve">
           <source>killed</source>
-          <target state="new">killed</target>
+          <target state="needs-review">убил</target>
         </trans-unit>
         <trans-unit id="LabelAudioBitrate" translate="yes" xml:space="preserve">
           <source>Audio bitrate:</source>
-          <target state="new">Audio bitrate:</target>
+          <target state="needs-review">Битрейт аудио:</target>
         </trans-unit>
         <trans-unit id="LabelCLI" translate="yes" xml:space="preserve">
           <source>Command-line input:</source>
-          <target state="new">Command-line input:</target>
+          <target state="needs-review">Ввод командной строки:</target>
         </trans-unit>
         <trans-unit id="LabelDurationSeconds" translate="yes" xml:space="preserve">
           <source>Duration (seconds):</source>
-          <target state="new">Duration (seconds):</target>
+          <target state="needs-review">Длительность (секунд):</target>
         </trans-unit>
         <trans-unit id="LabelEndTick" translate="yes" xml:space="preserve">
           <source>End tick:</source>
-          <target state="new">End tick:</target>
+          <target state="needs-review">Конечный тик:</target>
         </trans-unit>
         <trans-unit id="LabelExtraInputParams" translate="yes" xml:space="preserve">
           <source>Extra input parameters:</source>
-          <target state="new">Extra input parameters:</target>
+          <target state="needs-review">Дополнительные входные параметры:</target>
         </trans-unit>
         <trans-unit id="LabelExtraParams" translate="yes" xml:space="preserve">
           <source>Extra parameters:</source>
-          <target state="new">Extra parameters:</target>
+          <target state="needs-review">Дополнительные параметры:</target>
         </trans-unit>
         <trans-unit id="LabelFramerate" translate="yes" xml:space="preserve">
           <source>Framerate:</source>
-          <target state="new">Framerate:</target>
+          <target state="needs-review">Фреймрейт:</target>
         </trans-unit>
         <trans-unit id="LabelHeight" translate="yes" xml:space="preserve">
           <source>Height:</source>
-          <target state="new">Height:</target>
+          <target state="needs-review">Высота:</target>
         </trans-unit>
         <trans-unit id="LabelInstalledVersion" translate="yes" xml:space="preserve">
           <source>Installed version:</source>
-          <target state="new">Installed version:</target>
+          <target state="needs-review">Установленная версия:</target>
         </trans-unit>
         <trans-unit id="LabelOutputDestination" translate="yes" xml:space="preserve">
           <source>Output folder destination:</source>
-          <target state="new">Output folder destination:</target>
+          <target state="needs-review">Папка назначения выходных файлов:</target>
         </trans-unit>
         <trans-unit id="LabelOutputFilename" translate="yes" xml:space="preserve">
           <source>Output filename:</source>
-          <target state="new">Output filename:</target>
+          <target state="needs-review">Имя выходного файла:</target>
         </trans-unit>
         <trans-unit id="LabelRawFilesFolder" translate="yes" xml:space="preserve">
           <source>Raw files destination folder:</source>
-          <target state="new">Raw files destination folder:</target>
+          <target state="needs-review">Папка с исходными файлами:</target>
         </trans-unit>
         <trans-unit id="LabelStartTick" translate="yes" xml:space="preserve">
           <source>Start tick:</source>
-          <target state="new">Start tick:</target>
+          <target state="needs-review">Начальный тик:</target>
         </trans-unit>
         <trans-unit id="LabelVideoFramerate" translate="yes" xml:space="preserve">
           <source>Video framerate:</source>
-          <target state="new">Video framerate:</target>
+          <target state="needs-review">Фреймрейт видео:</target>
         </trans-unit>
         <trans-unit id="LabelVideoQuality" translate="yes" xml:space="preserve">
           <source>Video quality:</source>
-          <target state="new">Video quality:</target>
+          <target state="needs-review">Качество видео:</target>
         </trans-unit>
         <trans-unit id="LabelWidth" translate="yes" xml:space="preserve">
           <source>Width:</source>
-          <target state="new">Width:</target>
+          <target state="needs-review">Ширина:</target>
         </trans-unit>
         <trans-unit id="LoadingData" translate="yes" xml:space="preserve">
           <source>Loading data...</source>
-          <target state="new">Loading data...</target>
+          <target state="needs-review">Загрузка данных...</target>
         </trans-unit>
         <trans-unit id="OpenFolderOnEncodeEnd" translate="yes" xml:space="preserve">
           <source>Open video in Windows Explorer at the end of encoding</source>
-          <target state="new">Open video in Windows Explorer at the end of encoding</target>
+          <target state="needs-review">Открыть видео в Проводнике по окончании кодирования</target>
         </trans-unit>
         <trans-unit id="PlantedOnSite" translate="yes" xml:space="preserve">
           <source>planted the bomb on site</source>
-          <target state="new">planted the bomb on site</target>
+          <target state="needs-review">установил бомбу на точке</target>
         </trans-unit>
         <trans-unit id="RawFilesRequiredSpace" translate="yes" xml:space="preserve">
           <source>Raw files required space:</source>
-          <target state="new">Raw files required space:</target>
+          <target state="needs-review">Требуемое место для исходных файлов:</target>
         </trans-unit>
         <trans-unit id="RequiredSpaceNotAvailable" translate="yes" xml:space="preserve">
           <source>Required space calculation is not available with corrupted demos.</source>
-          <target state="new">Required space calculation is not available with corrupted demos.</target>
+          <target state="needs-review">Вычисление требуемого места для исходных файлов недоступно с поврежденными демками.</target>
         </trans-unit>
         <trans-unit id="Reset" translate="yes" xml:space="preserve">
           <source>Reset</source>
-          <target state="new">Reset</target>
+          <target state="needs-review">Сбросить</target>
         </trans-unit>
         <trans-unit id="RoundNumber" translate="yes" xml:space="preserve">
           <source>Round #</source>
-          <target state="new">Round #</target>
+          <target state="needs-review">Раунд #</target>
         </trans-unit>
         <trans-unit id="SelectFolder" translate="yes" xml:space="preserve">
           <source>Select folder</source>
-          <target state="new">Select folder</target>
+          <target state="needs-review">Выбрать папку</target>
         </trans-unit>
         <trans-unit id="SetTickAsEndTick" translate="yes" xml:space="preserve">
           <source>Set tick {0} as end tick</source>
-          <target state="new">Set tick {0} as end tick</target>
+          <target state="needs-review">Установить тик {0} как конечный тик</target>
         </trans-unit>
         <trans-unit id="ShowCFG" translate="yes" xml:space="preserve">
           <source>Show CFG</source>
-          <target state="new">Show CFG</target>
+          <target state="needs-review">Показать конфиг</target>
         </trans-unit>
         <trans-unit id="ShowDemoComment" translate="yes" xml:space="preserve">
           <source>Show demo comment</source>
-          <target state="new">Show demo comment</target>
+          <target state="needs-review">Показать комментарий к демке</target>
         </trans-unit>
         <trans-unit id="StartingCSGO" translate="yes" xml:space="preserve">
           <source>Starting CSGO, please wait...</source>
-          <target state="new">Starting CSGO, please wait...</target>
+          <target state="needs-review">Запускается CSGO, подождите...</target>
         </trans-unit>
         <trans-unit id="TimeLineNotAvailableWarning" translate="yes" xml:space="preserve">
           <source>Timeline is not available with POV or corrupted demos. You have to enter ticks manually. Adding a comment to the demo may be useful in this case.</source>
-          <target state="new">Timeline is not available with POV or corrupted demos. You have to enter ticks manually. Adding a comment to the demo may be useful in this case.</target>
+          <target state="needs-review">Временная шкала недоступна для POV или поврежденных демок. Вы должны вводить тики вручную. Также в таком случае будет полезно добавить комментарий к этой демке.</target>
         </trans-unit>
         <trans-unit id="ToolTipBrowseToFFmpegFolder" translate="yes" xml:space="preserve">
           <source>Open FFmpeg installation folder in Windows Explorer</source>
-          <target state="new">Open FFmpeg installation folder in Windows Explorer</target>
+          <target state="needs-review">Открыть папку установки FFmpeg в Проводнике</target>
         </trans-unit>
         <trans-unit id="ToolTipBrowseToHLAEFolder" translate="yes" xml:space="preserve">
           <source>Open HLAE installation folder in Window Explorer</source>
-          <target state="new">Open HLAE installation folder in Window Explorer</target>
+          <target state="needs-review">Открыть папку установки HLAE в Проводнике</target>
         </trans-unit>
         <trans-unit id="ToolTipBrowseToOutputDestination" translate="yes" xml:space="preserve">
           <source>Open output folder in Windows Explorer</source>
-          <target state="new">Open output folder in Windows Explorer</target>
+          <target state="needs-review">Открыть папку для выходных файлов в Проводнике</target>
         </trans-unit>
         <trans-unit id="ToolTipBrowseToRawFilesDestination" translate="yes" xml:space="preserve">
           <source>Open raw files folder in Windows Explorer</source>
-          <target state="new">Open raw files folder in Windows Explorer</target>
+          <target state="needs-review">Открыть папку исходных файлов в Проводнике</target>
         </trans-unit>
         <trans-unit id="ToolTipBrowseToVirtualDubFolder" translate="yes" xml:space="preserve">
           <source>Open VirtualDub installation folder in Window Explorer</source>
-          <target state="new">Open VirtualDub installation folder in Window Explorer</target>
+          <target state="needs-review">Открыть папку установки VirtualDub в Проводнике</target>
         </trans-unit>
         <trans-unit id="ToolTipChangeOutputDestination" translate="yes" xml:space="preserve">
           <source>Change output folder destination</source>
-          <target state="new">Change output folder destination</target>
+          <target state="needs-review">Изменить папку для выходных файлов</target>
         </trans-unit>
         <trans-unit id="ToolTipChangeRawFilesDestination" translate="yes" xml:space="preserve">
           <source>Change raw files folder destination</source>
-          <target state="new">Change raw files folder destination</target>
+          <target state="needs-review">Изменить папку исходных файлов</target>
         </trans-unit>
         <trans-unit id="ToolTipGenerateMovie" translate="yes" xml:space="preserve">
           <source>Start movie generation</source>
-          <target state="new">Start movie generation</target>
+          <target state="needs-review">Начать создание видеофайла</target>
         </trans-unit>
         <trans-unit id="ToolTipInstallFFmpeg" translate="yes" xml:space="preserve">
           <source>Install FFmpeg</source>
-          <target state="new">Install FFmpeg</target>
+          <target state="needs-review">Установить FFmpeg</target>
         </trans-unit>
         <trans-unit id="ToolTipInstallHLAE" translate="yes" xml:space="preserve">
           <source>Install HLAE</source>
-          <target state="new">Install HLAE</target>
+          <target state="needs-review">Установить HLAE</target>
         </trans-unit>
         <trans-unit id="ToolTipInstallVirtualDub" translate="yes" xml:space="preserve">
           <source>Install VirtualDub</source>
-          <target state="new">Install VirtualDub</target>
+          <target state="needs-review">Установить VirtualDub</target>
         </trans-unit>
         <trans-unit id="ToolTipResetCFG" translate="yes" xml:space="preserve">
           <source>Reset CFG to default</source>
-          <target state="new">Reset CFG to default</target>
+          <target state="needs-review">Сбросить конфиг к умолчаниям</target>
         </trans-unit>
         <trans-unit id="ToolTipSelectCsgoExeLocation" translate="yes" xml:space="preserve">
           <source>Change csgo.exe location</source>
-          <target state="new">Change csgo.exe location</target>
+          <target state="needs-review">Изменить расположение файла csgo.exe</target>
         </trans-unit>
         <trans-unit id="ToolTipSwitchBetweenFFmpegVirtualDub" translate="yes" xml:space="preserve">
           <source>Switch between VirtualDub / FFmpeg</source>
-          <target state="new">Switch between VirtualDub / FFmpeg</target>
+          <target state="needs-review">Переключиться между VirtualDub / FFmpeg</target>
         </trans-unit>
         <trans-unit id="ToolTipToggleDemoComment" translate="yes" xml:space="preserve">
           <source>Toggle demo's comment (CTRL+T)</source>
-          <target state="new">Toggle demo's comment (CTRL+T)</target>
+          <target state="needs-review">Переключить комментарий демки (CTRL+T)</target>
         </trans-unit>
         <trans-unit id="ToolTipUpdateHLAE" translate="yes" xml:space="preserve">
           <source>Update HLAE</source>
-          <target state="new">Update HLAE</target>
+          <target state="needs-review">Обновить HLAE</target>
         </trans-unit>
         <trans-unit id="ValidNumberRequired" translate="yes" xml:space="preserve">
           <source>A valid number is required.</source>
-          <target state="new">A valid number is required.</target>
+          <target state="needs-review">Требуется корректное число.</target>
         </trans-unit>
         <trans-unit id="VirtualDubEncodingInProgress" translate="yes" xml:space="preserve">
           <source>VirtualDub encoding in progress, please wait...</source>
-          <target state="new">VirtualDub encoding in progress, please wait...</target>
+          <target state="needs-review">VirtualDub кодирование в процессе, подождите...</target>
         </trans-unit>
         <trans-unit id="With" translate="yes" xml:space="preserve">
           <source>with</source>
-          <target state="new">with</target>
+          <target state="needs-review">с</target>
         </trans-unit>
         <trans-unit id="ContextMenuTimeLineSetEventTickAsEndTick" translate="yes" xml:space="preserve">
           <source>Set the tick {0} as end tick</source>
-          <target state="new">Set the tick {0} as end tick</target>
+          <target state="needs-review">Установить тик {0} как конечный тик</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Set the tick "of the flash" as end tick</note>
         </trans-unit>
         <trans-unit id="ContextMenuTimeLineSetEventTickAsStartTick" translate="yes" xml:space="preserve">
           <source>Set the tick {0} as start tick</source>
-          <target state="new">Set the tick {0} as start tick</target>
+          <target state="needs-review">Установить тик {0} как начальный тик</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Set the tick "of the flash" as start tick</note>
         </trans-unit>
         <trans-unit id="ContextMenuTimeLineSetEventTickMinusAsEndTick" translate="yes" xml:space="preserve">
           <source>Set the tick {0} minus x seconds as end tick</source>
-          <target state="new">Set the tick {0} minus x seconds as end tick</target>
+          <target state="needs-review">Установить тик {0} минус х секунд как конечный тик</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Set the tick "of the flash" minus x seconds as end tick</note>
         </trans-unit>
         <trans-unit id="ContextMenuTimeLineSetEventTickMinusAsStartTick" translate="yes" xml:space="preserve">
           <source>Set the tick {0} minus x seconds as start tick</source>
-          <target state="new">Set the tick {0} minus x seconds as start tick</target>
+          <target state="needs-review">Установить тик {0} минус х секунд как начальный тик</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Set the tick "of the flash" minus x seconds as start tick</note>
         </trans-unit>
         <trans-unit id="ContextMenuTimeLineSetEventTickPlusAsEndTick" translate="yes" xml:space="preserve">
           <source>Set the tick {0} plus x seconds as end tick</source>
-          <target state="new">Set the tick {0} plus x seconds as end tick</target>
+          <target state="needs-review">Установить тик {0} плюс х секунд как конечный тик</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Set the tick "of the flash" plus x seconds as end tick</note>
         </trans-unit>
         <trans-unit id="ContextMenuTimeLineSetEventTickPlusAsStartTick" translate="yes" xml:space="preserve">
           <source>Set the tick {0} plus x seconds as start tick</source>
-          <target state="new">Set the tick {0} plus x seconds as start tick</target>
+          <target state="needs-review">Установить тик {0} плюс х секунд как начальный тик</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Set the tick "of the flash" plus x seconds as start tick</note>
         </trans-unit>
         <trans-unit id="FocusOnDefuser" translate="yes" xml:space="preserve">
           <source>Focus on defuser</source>
-          <target state="new">Focus on defuser</target>
+          <target state="needs-review">Фокус на разминирующем</target>
         </trans-unit>
         <trans-unit id="FocusOnPlanter" translate="yes" xml:space="preserve">
           <source>Focus on planter</source>
-          <target state="new">Focus on planter</target>
+          <target state="needs-review">Фокус на устанавливающем</target>
         </trans-unit>
         <trans-unit id="FocusOnKiller" translate="yes" xml:space="preserve">
           <source>Focus on killer</source>
-          <target state="new">Focus on killer</target>
+          <target state="needs-review">Фокус на убийце</target>
         </trans-unit>
         <trans-unit id="Movie" translate="yes" xml:space="preserve">
           <source>Movie</source>
-          <target state="new">Movie</target>
+          <target state="needs-review">Видеофайл</target>
         </trans-unit>
         <trans-unit id="ToolTipMovie" translate="yes" xml:space="preserve">
           <source>Go to movie generator</source>
-          <target state="new">Go to movie generator</target>
+          <target state="needs-review">Перейти к созданию видеофайла</target>
         </trans-unit>
         <trans-unit id="Adecoy" translate="yes" xml:space="preserve">
           <source>a decoy</source>
-          <target state="new">a decoy</target>
+          <target state="needs-review">отвлекающую гранату</target>
         </trans-unit>
         <trans-unit id="AFlashbang" translate="yes" xml:space="preserve">
           <source>a flashbang</source>
-          <target state="new">a flashbang</target>
+          <target state="needs-review">световую гранату</target>
         </trans-unit>
         <trans-unit id="AMolotov" translate="yes" xml:space="preserve">
           <source>a molotov</source>
-          <target state="new">a molotov</target>
+          <target state="needs-review">коктейль Молотова</target>
         </trans-unit>
         <trans-unit id="AnHE" translate="yes" xml:space="preserve">
           <source>an HE</source>
-          <target state="new">an HE</target>
+          <target state="needs-review">БГ</target>
         </trans-unit>
         <trans-unit id="AnIncendiary" translate="yes" xml:space="preserve">
           <source>an incendiary</source>
-          <target state="new">an incendiary</target>
+          <target state="needs-review">зажигательную гранату</target>
         </trans-unit>
         <trans-unit id="Asmoke" translate="yes" xml:space="preserve">
           <source>a smoke</source>
-          <target state="new">a smoke</target>
+          <target state="needs-review">дымовую гранату</target>
         </trans-unit>
         <trans-unit id="Thrown" translate="yes" xml:space="preserve">
           <source>thrown</source>
-          <target state="new">thrown</target>
+          <target state="needs-review">брошена</target>
         </trans-unit>
         <trans-unit id="ToolTipShowCFG" translate="yes" xml:space="preserve">
           <source>Show CFG</source>
-          <target state="new">Show CFG</target>
+          <target state="needs-review">Показать конфиг</target>
         </trans-unit>
         <trans-unit id="Website" translate="yes" xml:space="preserve">
           <source>Website</source>
-          <target state="new">Website</target>
+          <target state="needs-review">Сайт</target>
         </trans-unit>
         <trans-unit id="DialogNoHLAEUpdateAvailable" translate="yes" xml:space="preserve">
           <source>No HLAE update available.</source>
-          <target state="new">No HLAE update available.</target>
+          <target state="needs-review">Нет обновлений для HLAE.</target>
         </trans-unit>
         <trans-unit id="NotificationInstallingFFmpeg" translate="yes" xml:space="preserve">
           <source>Installing FFmpeg...</source>
-          <target state="new">Installing FFmpeg...</target>
+          <target state="needs-review">Устанавливается FFmpeg...</target>
         </trans-unit>
         <trans-unit id="CreditsTools" translate="yes" xml:space="preserve">
           <source>CSGO Demo Manager uses internally the following tools:</source>
-          <target state="new">CSGO Demo Manager uses internally the following tools:</target>
+          <target state="needs-review">CSGO Demo Manager использует следующие инструменты:</target>
         </trans-unit>
         <trans-unit id="Tools" translate="yes" xml:space="preserve">
           <source>Tools</source>
-          <target state="new">Tools</target>
+          <target state="needs-review">Инструменты</target>
         </trans-unit>
         <trans-unit id="SeeDocOnWebsite" translate="yes" xml:space="preserve">
           <source>See documentation on the website</source>
-          <target state="new">See documentation on the website</target>
+          <target state="needs-review">Смотрите документацию на сайте</target>
         </trans-unit>
         <trans-unit id="Markers" translate="yes" xml:space="preserve">
           <source>Markers</source>
-          <target state="new">Markers</target>
+          <target state="needs-review">Маркеры</target>
         </trans-unit>
         <trans-unit id="Actions" translate="yes" xml:space="preserve">
           <source>Actions</source>
-          <target state="new">Actions</target>
+          <target state="needs-review">Действия</target>
         </trans-unit>
         <trans-unit id="ContextMenuDisplayKillsOnyForPlayer" translate="yes" xml:space="preserve">
           <source>Display kills only for this player</source>
-          <target state="new">Display kills only for this player</target>
+          <target state="needs-review">Отображать убийства только этого игрока</target>
         </trans-unit>
         <trans-unit id="ContextMenuHighlightKillsOnlyForPlayer" translate="yes" xml:space="preserve">
           <source>Highlight kills only for this player</source>
-          <target state="new">Highlight kills only for this player</target>
+          <target state="needs-review">Подсвечивать убийства только этого игрока</target>
         </trans-unit>
         <trans-unit id="CopySteamID" translate="yes" xml:space="preserve">
           <source>Copy SteamID</source>
-          <target state="new">Copy SteamID</target>
+          <target state="needs-review">Скопировать SteamID</target>
         </trans-unit>
         <trans-unit id="DeathNoticesOptions" translate="yes" xml:space="preserve">
           <source>Death notices options</source>
-          <target state="new">Death notices options</target>
+          <target state="needs-review">Настройки уведомлений о смерти</target>
         </trans-unit>
         <trans-unit id="DisplayKills" translate="yes" xml:space="preserve">
           <source>Display kills</source>
-          <target state="new">Display kills</target>
+          <target state="needs-review">Отображать убийства</target>
         </trans-unit>
         <trans-unit id="HeaderToolDisplayKillsForPlayer" translate="yes" xml:space="preserve">
           <source>Display kills for this player on death notices</source>
-          <target state="new">Display kills for this player on death notices</target>
+          <target state="needs-review">Отображать убийства для этого игрока в уведомлениях о смерти</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipHighlightKillsForPlayer" translate="yes" xml:space="preserve">
           <source>Highlight kills for this player on death notices</source>
-          <target state="new">Highlight kills for this player on death notices</target>
+          <target state="needs-review">Подсвечивать убийства для этого игрока в уведомлениях о смерти</target>
         </trans-unit>
         <trans-unit id="HighlightKills" translate="yes" xml:space="preserve">
           <source>Highlight kills</source>
-          <target state="new">Highlight kills</target>
+          <target state="needs-review">Подсвечивать убийства</target>
         </trans-unit>
         <trans-unit id="LabelDisplayTimeSeconds" translate="yes" xml:space="preserve">
           <source>Display time (seconds):</source>
-          <target state="new">Display time (seconds):</target>
+          <target state="needs-review">Оотображать время (секунды):</target>
         </trans-unit>
         <trans-unit id="CheckForUpdatesOnAppStartup" translate="yes" xml:space="preserve">
           <source>Check for updates on app startup</source>
-          <target state="new">Check for updates on app startup</target>
+          <target state="needs-review">Проверять на обновления при запуске</target>
         </trans-unit>
         <trans-unit id="MaxConcurrentAnalyzes" translate="yes" xml:space="preserve">
           <source>Max concurrent demo analyzes</source>
-          <target state="new">Max concurrent demo analyzes</target>
+          <target state="needs-review">Максимальное число одновременно обрабатываемых демок</target>
         </trans-unit>
         <trans-unit id="TooltipCancel" translate="yes" xml:space="preserve">
           <source>Cancel</source>
-          <target state="new">Cancel</target>
+          <target state="needs-review">Отменить</target>
         </trans-unit>
         <trans-unit id="DialogErrorDownloadingDemos" translate="yes" xml:space="preserve">
           <source>An error occurred while downloading demos.</source>
-          <target state="new">An error occurred while downloading demos.</target>
+          <target state="needs-review">Возникла ошибка при скачивании демок.</target>
         </trans-unit>
         <trans-unit id="DialogUnknownBoilerExitCode" translate="yes" xml:space="preserve">
           <source>An unknown error happened, code: ({0}).</source>
-          <target state="new">An unknown error happened, code: ({0}).</target>
+          <target state="needs-review">Возникла неизвестная ошибка, код: ({0}).</target>
         </trans-unit>
         <trans-unit id="HeaderKast" translate="yes" xml:space="preserve">
           <source>KAST</source>
-          <target state="new">KAST</target>
+          <target state="needs-review">УПВР</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipKast" translate="yes" xml:space="preserve">
           <source>Percentage of rounds in which the player either had a kill, assist, survived or was traded</source>
-          <target state="new">Percentage of rounds in which the player either had a kill, assist, survived or was traded</target>
+          <target state="needs-review">Процент раундов, в которых игрок убил, помог, выжил или был разменян</target>
         </trans-unit>
         <trans-unit id="Kast" translate="yes" xml:space="preserve">
           <source>KAST</source>
-          <target state="new">KAST</target>
+          <target state="needs-review">УПВР</target>
         </trans-unit>
         <trans-unit id="Chat" translate="yes" xml:space="preserve">
           <source>Chat</source>
-          <target state="new">Chat</target>
+          <target state="needs-review">Чат</target>
         </trans-unit>
         <trans-unit id="TooltipChat" translate="yes" xml:space="preserve">
           <source>Chat</source>
-          <target state="new">Chat</target>
+          <target state="needs-review">Чат</target>
         </trans-unit>
         <trans-unit id="LabelEnableCustomLocation" translate="yes" xml:space="preserve">
           <source>Enable custom location</source>
-          <target state="new">Enable custom location</target>
+          <target state="needs-review">Разрешить выборочный путь</target>
         </trans-unit>
         <trans-unit id="DialogExecutableNotFound" translate="yes" xml:space="preserve">
           <source>Executable not found.</source>
-          <target state="new">Executable not found.</target>
+          <target state="needs-review">Исполняемый файл не найден.</target>
         </trans-unit>
         <trans-unit id="DialogInvalidExecutable" translate="yes" xml:space="preserve">
           <source>Invalid executable.</source>
-          <target state="new">Invalid executable.</target>
+          <target state="needs-review">Неверный исполняемый файл.</target>
         </trans-unit>
         <trans-unit id="DialogInvalidHlaeExecutablePath" translate="yes" xml:space="preserve">
           <source>The path contains non-basic latin characters which may lead to unexpected behaviors in-game. Please select a folder that contains only 7-bit ASCII characters.</source>
-          <target state="new">The path contains non-basic latin characters which may lead to unexpected behaviors in-game. Please select a folder that contains only 7-bit ASCII characters.</target>
+          <target state="needs-review">Путь содержит нестандартные латинские символы, что может привести к неожиданным последствиям в игре. Выберите папку, содержащую только 7-битные ASCII символы.</target>
         </trans-unit>
         <trans-unit id="HlaeNotFound" translate="yes" xml:space="preserve">
           <source>HLAE not found. Please install it by enabling it from settings.</source>
-          <target state="new">HLAE not found. Please install it by enabling it from settings.</target>
+          <target state="needs-review">HLAE не найден. Установите его, включив его в настройках.</target>
         </trans-unit>
         <trans-unit id="DialogErrorKillingCsgo" translate="yes" xml:space="preserve">
           <source>Failed to close CSGO, please do it manually and try again.
 Error: {0}.</source>
-          <target state="new">Failed to close CSGO, please do it manually and try again.
-Error: {0}.</target>
+          <target state="needs-review">Ошибка при закрытии CSGO, сделайте это вручную и попробуйте снова.
+Ошибка: {0}.</target>
         </trans-unit>
         <trans-unit id="DialogErrorKillingHlae" translate="yes" xml:space="preserve">
           <source>Failed to close HLAE, please do it manually and try again.
 Error: {0}.</source>
-          <target state="new">Failed to close HLAE, please do it manually and try again.
-Error: {0}.</target>
+          <target state="needs-review">Ошибка при закрытии HLAE, сделайте это вручную и попробуйте снова.
+Ошибка: {0}.</target>
         </trans-unit>
         <trans-unit id="DialogErrorStartingCsgo" translate="yes" xml:space="preserve">
           <source>Failed to start CSGO.
 Error: {0}.</source>
-          <target state="new">Failed to start CSGO.
-Error: {0}.</target>
+          <target state="needs-review">Ошибка при запуске CSGO.
+Ошибка: {0}.</target>
         </trans-unit>
         <trans-unit id="DialogInvalidDemo" translate="yes" xml:space="preserve">
           <source>Invalid demo file.</source>
-          <target state="new">Invalid demo file.</target>
+          <target state="needs-review">Неверный файл демки.</target>
         </trans-unit>
         <trans-unit id="DialogExportAllDemosConfirmation" translate="yes" xml:space="preserve">
           <source>Do you want to export only the selected demos or all the demos within the selected folder?</source>
-          <target state="new">Do you want to export only the selected demos or all the demos within the selected folder?</target>
+          <target state="needs-review">Вы хотите экспортировать только выбранные демки или все демки внутри выбранной папки?</target>
         </trans-unit>
         <trans-unit id="LabelAudioCodec" translate="yes" xml:space="preserve">
           <source>Audio codec</source>
-          <target state="new">Audio codec</target>
+          <target state="needs-review">Аудио кодек</target>
         </trans-unit>
         <trans-unit id="LabelVideoCodec" translate="yes" xml:space="preserve">
           <source>Video codec</source>
-          <target state="new">Video codec</target>
+          <target state="needs-review">Видео кодек</target>
         </trans-unit>
         <trans-unit id="LabelDate" translate="yes" xml:space="preserve">
           <source>Date</source>
-          <target state="new">Date</target>
+          <target state="needs-review">Дата</target>
         </trans-unit>
         <trans-unit id="ExportPlayersVoice" translate="yes" xml:space="preserve">
           <source>Export players voice</source>
-          <target state="new">Export players voice</target>
+          <target state="needs-review">Экспортировать голос игроков</target>
         </trans-unit>
         <trans-unit id="CsgoNotFound" translate="yes" xml:space="preserve">
           <source>CSGO not found.</source>
-          <target state="new">CSGO not found.</target>
+          <target state="needs-review">CSGO не найдена.</target>
         </trans-unit>
         <trans-unit id="FailedToParseDemo" translate="yes" xml:space="preserve">
           <source>{0}: Failed to parse demo.</source>
-          <target state="new">{0}: Failed to parse demo.</target>
+          <target state="needs-review">{0}: Не удалось обработать демку.</target>
         </trans-unit>
         <trans-unit id="CsgoAudioLibraryNotFound" translate="yes" xml:space="preserve">
           <source>CSGO audio library not found.</source>
-          <target state="new">CSGO audio library not found.</target>
+          <target state="needs-review">Аудио библиотека CSGO не найдена.</target>
         </trans-unit>
         <trans-unit id="DemoNotFound" translate="yes" xml:space="preserve">
           <source>{0}: Demo not found.</source>
-          <target state="new">{0}: Demo not found.</target>
+          <target state="needs-review">{0}: Демка не найдена.</target>
         </trans-unit>
         <trans-unit id="FailedToLoadCsgoAudioLibrary" translate="yes" xml:space="preserve">
           <source>Failed to load CSGO audio library.</source>
-          <target state="new">Failed to load CSGO audio library.</target>
+          <target state="needs-review">Ошибка при запуске аудио библиотеки CSGO.</target>
         </trans-unit>
         <trans-unit id="NoPlayersVoiceDataFound" translate="yes" xml:space="preserve">
           <source>{0}: No players voice data found.</source>
-          <target state="new">{0}: No players voice data found.</target>
+          <target state="needs-review">{0}: Голосовые данные игроков не найдены.</target>
         </trans-unit>
         <trans-unit id="UnsupportedAudioCodec" translate="yes" xml:space="preserve">
           <source>{0}: Unsupported audio codec.</source>
-          <target state="new">{0}: Unsupported audio codec.</target>
+          <target state="needs-review">{0}: Неподдерживаемый аудио кодек.</target>
         </trans-unit>
         <trans-unit id="DialogExportDone" translate="yes" xml:space="preserve">
           <source>Export done.</source>
-          <target state="new">Export done.</target>
+          <target state="needs-review">Экспорт выполнен.</target>
         </trans-unit>
         <trans-unit id="WatchAsSuspect" translate="yes" xml:space="preserve">
           <source>Watch as a suspect</source>
-          <target state="new">Watch as a suspect</target>
+          <target state="needs-review">Смотреть как подозреваемого</target>
         </trans-unit>
         <trans-unit id="DialogStartingCsgoAccessDenied" translate="yes" xml:space="preserve">
           <source>Access was denied when trying to start CSGO. Make sure to close any running anti cheat software and retry.</source>
-          <target state="new">Access was denied when trying to start CSGO. Make sure to close any running anti cheat software and retry.</target>
+          <target state="needs-review">Доступ запрещен при попытке запустить CSGO. Убедитесь, что закрыли все запущенные античитерские программы и попробуйте снова.</target>
         </trans-unit>
         <trans-unit id="DemoTypeGotv" translate="yes" xml:space="preserve">
           <source>GOTV</source>
-          <target state="new">GOTV</target>
+          <target state="needs-review">GOTV</target>
         </trans-unit>
         <trans-unit id="DemoTypePov" translate="yes" xml:space="preserve">
           <source>POV</source>
-          <target state="new">POV</target>
+          <target state="needs-review">POV</target>
         </trans-unit>
       </group>
     </body>

--- a/Manager/MultilingualResources/Manager.ru.xlf
+++ b/Manager/MultilingualResources/Manager.ru.xlf
@@ -713,7 +713,7 @@
         </trans-unit>
         <trans-unit id="Flashbangs" translate="yes" xml:space="preserve">
           <source>Flashbangs</source>
-          <target state="needs-review">Ослепления</target>
+          <target state="needs-review">Световая</target>
         </trans-unit>
         <trans-unit id="Heatmap" translate="yes" xml:space="preserve">
           <source>Heatmap</source>
@@ -753,7 +753,7 @@
         </trans-unit>
         <trans-unit id="LabelMostKillingWeapon" translate="yes" xml:space="preserve">
           <source>Most killing weapon</source>
-          <target state="needs-review">Самое убивающее оружие</target>
+          <target state="needs-review">Самое смертоносное оружие</target>
         </trans-unit>
         <trans-unit id="LabelPlayerStats" translate="yes" xml:space="preserve">
           <source>Player stats</source>
@@ -1608,7 +1608,7 @@
         </trans-unit>
         <trans-unit id="Decoys" translate="yes" xml:space="preserve">
           <source>Decoys</source>
-          <target state="needs-review">Отвлекающие гранаты</target>
+          <target state="needs-review">Отвлекающая</target>
         </trans-unit>
         <trans-unit id="EndReasonBombDefused" translate="yes" xml:space="preserve">
           <source>Bomb defused</source>
@@ -1676,11 +1676,11 @@
         </trans-unit>
         <trans-unit id="HeGrenades" translate="yes" xml:space="preserve">
           <source>HE Grenades</source>
-          <target state="needs-review">Осколочные гранаты</target>
+          <target state="needs-review">Осколочная</target>
         </trans-unit>
         <trans-unit id="Incendiaries" translate="yes" xml:space="preserve">
           <source>Incendiaries</source>
-          <target state="needs-review">Зажигательные</target>
+          <target state="needs-review">Зажигательная</target>
         </trans-unit>
         <trans-unit id="LabelWinnerSide" translate="yes" xml:space="preserve">
           <source>Winner side</source>
@@ -1688,7 +1688,7 @@
         </trans-unit>
         <trans-unit id="Molotovs" translate="yes" xml:space="preserve">
           <source>Molotovs</source>
-          <target state="needs-review">Коктейли Иолотова</target>
+          <target state="needs-review">Молотов</target>
         </trans-unit>
         <trans-unit id="Players" translate="yes" xml:space="preserve">
           <source>Players</source>
@@ -1700,7 +1700,7 @@
         </trans-unit>
         <trans-unit id="Smoke" translate="yes" xml:space="preserve">
           <source>Smoke</source>
-          <target state="needs-review">Дымовые гранаты</target>
+          <target state="needs-review">Дымовая</target>
         </trans-unit>
         <trans-unit id="StartMoney" translate="yes" xml:space="preserve">
           <source>Start money</source>
@@ -1857,7 +1857,7 @@
         </trans-unit>
         <trans-unit id="Round" translate="yes" xml:space="preserve">
           <source>Round</source>
-          <target state="needs-review">Раундов</target>
+          <target state="needs-review">Раунд</target>
         </trans-unit>
         <trans-unit id="RoundTypeEco" translate="yes" xml:space="preserve">
           <source>Eco</source>
@@ -2611,7 +2611,7 @@ You can find more information on {1}.</source>
         </trans-unit>
         <trans-unit id="Both" translate="yes" xml:space="preserve">
           <source>Both</source>
-          <target state="needs-review">Оба</target>
+          <target state="needs-review">Обе</target>
         </trans-unit>
         <trans-unit id="CounterTerrorists" translate="yes" xml:space="preserve">
           <source>Counter-Terrorists</source>
@@ -2967,7 +2967,7 @@ You have to remove it from your account list to be able to add him in your white
         </trans-unit>
         <trans-unit id="Smokes" translate="yes" xml:space="preserve">
           <source>Smokes</source>
-          <target state="needs-review">Дымовые гранаты</target>
+          <target state="needs-review">Дымовая</target>
         </trans-unit>
         <trans-unit id="CT" translate="yes" xml:space="preserve">
           <source>CT</source>
@@ -3598,23 +3598,23 @@ You may have missing data for this demos.</source>
         </trans-unit>
         <trans-unit id="Decoy" translate="yes" xml:space="preserve">
           <source>Decoy</source>
-          <target state="needs-review">Отвлекающая граната</target>
+          <target state="needs-review">Отвлекающая</target>
         </trans-unit>
         <trans-unit id="Flashbang" translate="yes" xml:space="preserve">
           <source>Flashbang</source>
-          <target state="needs-review">Световая граната</target>
+          <target state="needs-review">Световая</target>
         </trans-unit>
         <trans-unit id="HE" translate="yes" xml:space="preserve">
           <source>HE</source>
-          <target state="needs-review">ОГ</target>
+          <target state="needs-review">Осколочная</target>
         </trans-unit>
         <trans-unit id="Incendiary" translate="yes" xml:space="preserve">
           <source>Incendiary</source>
-          <target state="needs-review">Зажигательная граната</target>
+          <target state="needs-review">Зажигательная</target>
         </trans-unit>
         <trans-unit id="Molotov" translate="yes" xml:space="preserve">
           <source>Molotov</source>
-          <target state="needs-review">Коктейль Молотова</target>
+          <target state="needs-review">Молотов</target>
         </trans-unit>
         <trans-unit id="FocusOnPlayer" translate="yes" xml:space="preserve">
           <source>Focus on player</source>
@@ -4276,11 +4276,11 @@ Error: {0}.</source>
         </trans-unit>
         <trans-unit id="ExportPlayersVoice" translate="yes" xml:space="preserve">
           <source>Export players voice</source>
-          <target state="needs-review">Экспорт голосового чата</target>
+          <target state="needs-review">Экспорт голосов игроков</target>
         </trans-unit>
         <trans-unit id="CsgoNotFound" translate="yes" xml:space="preserve">
           <source>CSGO not found.</source>
-          <target state="needs-review">CSGO не найдена.</target>
+          <target state="needs-review">Не удалось найти CSGO.</target>
         </trans-unit>
         <trans-unit id="FailedToParseDemo" translate="yes" xml:space="preserve">
           <source>{0}: Failed to parse demo.</source>

--- a/Manager/MultilingualResources/Manager.ru.xlf
+++ b/Manager/MultilingualResources/Manager.ru.xlf
@@ -936,7 +936,7 @@
         </trans-unit>
         <trans-unit id="HeaderToolTipAccountProfileUrl" translate="yes" xml:space="preserve">
           <source>Account's Profile URL</source>
-          <target state="needs-review">Ссылка на Профиль Аккаунта</target>>
+          <target state="needs-review">Ссылка на Профиль Аккаунта</target>
         </trans-unit>
         <trans-unit id="HeaderToolTipAccountStatus" translate="yes" xml:space="preserve">
           <source>Account's Status (offline, online...)</source>
@@ -4069,7 +4069,7 @@ Please update it by clicking on the "Update" button.</source>
           <target state="needs-review">Фокус на убийце</target>
         </trans-unit>
         <trans-unit id="Movie" translate="yes" xml:space="preserve">
-          <source>Movie</source>о
+          <source>Movie</source>
           <target state="needs-review">Видеофайл</target>
         </trans-unit>
         <trans-unit id="ToolTipMovie" translate="yes" xml:space="preserve">

--- a/Services/MultilingualResources/Services.ru.xlf
+++ b/Services/MultilingualResources/Services.ru.xlf
@@ -28,7 +28,7 @@
         </trans-unit>
         <trans-unit id="HE" translate="yes" xml:space="preserve">
           <source>HE</source>
-          <target state="needs-review">Боевая граната</target>
+          <target state="needs-review">Осколочная граната</target>
         </trans-unit>
         <trans-unit id="Killed" translate="yes" xml:space="preserve">
           <source>{0} killed {1}</source>
@@ -64,7 +64,7 @@
         </trans-unit>
         <trans-unit id="ThrownHeGrenade" translate="yes" xml:space="preserve">
           <source>{0} thrown a HE grenade</source>
-          <target state="needs-review">{0} бросил боевую гранату</target>
+          <target state="needs-review">{0} бросил осколочную гранату</target>
         </trans-unit>
         <trans-unit id="ThrownIncendiary" translate="yes" xml:space="preserve">
           <source>{0} thrown an incendiary</source>
@@ -137,7 +137,7 @@
         </trans-unit>
         <trans-unit id="HEEventName" translate="yes" xml:space="preserve">
           <source>of the HE</source>
-          <target state="needs-review">боевой гранаты</target>
+          <target state="needs-review">осколочной гранаты</target>
         </trans-unit>
         <trans-unit id="Incendiary" translate="yes" xml:space="preserve">
           <source>Incendiary</source>

--- a/Services/MultilingualResources/Services.ru.xlf
+++ b/Services/MultilingualResources/Services.ru.xlf
@@ -8,7 +8,7 @@
       <group id="SERVICES/PROPERTIES/RESOURCES.RESX" datatype="resx">
         <trans-unit id="Bomb" translate="yes" xml:space="preserve">
           <source>Bomb</source>
-          <target state="new">Bomb</target>
+          <target state="needs-review">Бомба</target>
         </trans-unit>
         <trans-unit id="colors" translate="no" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
           <source>..\resources\images\colors.jpg;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</source>
@@ -16,35 +16,35 @@
         </trans-unit>
         <trans-unit id="Decoy" translate="yes" xml:space="preserve">
           <source>Decoy</source>
-          <target state="new">Decoy</target>
+          <target state="needs-review">Отвлекающая граната</target>
         </trans-unit>
         <trans-unit id="DefusedTheBombOnBombSite" translate="yes" xml:space="preserve">
           <source>{0} defused the bomb on bomb site {1}</source>
-          <target state="new">{0} defused the bomb on bomb site {1}</target>
+          <target state="needs-review">{0} разминировал бомбу на точке {1}</target>
         </trans-unit>
         <trans-unit id="Flashbang" translate="yes" xml:space="preserve">
           <source>Flashbang</source>
-          <target state="new">Flashbang</target>
+          <target state="needs-review">Световая граната</target>
         </trans-unit>
         <trans-unit id="HE" translate="yes" xml:space="preserve">
           <source>HE</source>
-          <target state="new">HE</target>
+          <target state="needs-review">Боевая граната</target>
         </trans-unit>
         <trans-unit id="Killed" translate="yes" xml:space="preserve">
           <source>{0} killed {1}</source>
-          <target state="new">{0} killed {1}</target>
+          <target state="needs-review">{0} убил {1}</target>
         </trans-unit>
         <trans-unit id="Molotov" translate="yes" xml:space="preserve">
           <source>Molotov</source>
-          <target state="new">Molotov</target>
+          <target state="needs-review">Коктейль Молотова</target>
         </trans-unit>
         <trans-unit id="PlantedTheBombOnBombSite" translate="yes" xml:space="preserve">
           <source>{0} planted the bomb on bomb site {1}</source>
-          <target state="new">{0} planted the bomb on bomb site {1}</target>
+          <target state="needs-review">{0} установил бомбу на точке {1}</target>
         </trans-unit>
         <trans-unit id="Smoke" translate="yes" xml:space="preserve">
           <source>Smoke</source>
-          <target state="new">Smoke</target>
+          <target state="needs-review">Дымовая граната</target>
         </trans-unit>
         <trans-unit id="steam_api_key" translate="no" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
           <source>..\resources\steam_api_key.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</source>
@@ -52,31 +52,31 @@
         </trans-unit>
         <trans-unit id="TheBombExplodedOnBombSite" translate="yes" xml:space="preserve">
           <source>The bomb exploded on bomb site {0}</source>
-          <target state="new">The bomb exploded on bomb site {0}</target>
+          <target state="needs-review">Бомба взорвалась на точке {0}</target>
         </trans-unit>
         <trans-unit id="ThrownDecoy" translate="yes" xml:space="preserve">
           <source>{0} thrown a decoy</source>
-          <target state="new">{0} thrown a decoy</target>
+          <target state="needs-review">{0} бросил отвлекающую гранату</target>
         </trans-unit>
         <trans-unit id="ThrownFlashbang" translate="yes" xml:space="preserve">
           <source>{0} thrown a flashbang</source>
-          <target state="new">{0} thrown a flashbang</target>
+          <target state="needs-review">{0} бросил световую гранату</target>
         </trans-unit>
         <trans-unit id="ThrownHeGrenade" translate="yes" xml:space="preserve">
           <source>{0} thrown a HE grenade</source>
-          <target state="new">{0} thrown a HE grenade</target>
+          <target state="needs-review">{0} бросил боевую гранату</target>
         </trans-unit>
         <trans-unit id="ThrownIncendiary" translate="yes" xml:space="preserve">
           <source>{0} thrown an incendiary</source>
-          <target state="new">{0} thrown an incendiary</target>
+          <target state="needs-review">{0} бросил зажигательную гранату</target>
         </trans-unit>
         <trans-unit id="ThrownMolotov" translate="yes" xml:space="preserve">
           <source>{0} thrown a molotov</source>
-          <target state="new">{0} thrown a molotov</target>
+          <target state="needs-review">{0} бросил коктейль Молотова</target>
         </trans-unit>
         <trans-unit id="ThrownSmoke" translate="yes" xml:space="preserve">
           <source>{0} thrown a smoke</source>
-          <target state="new">{0} thrown a smoke</target>
+          <target state="needs-review">{0} бросил дымовую гранату</target>
         </trans-unit>
         <trans-unit id="execute_command" translate="no" xml:space="preserve" extype="System.Resources.ResXFileRef, System.Windows.Forms">
           <source>..\resources\vdm\execute_command.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</source>
@@ -112,64 +112,64 @@
         </trans-unit>
         <trans-unit id="Kill" translate="yes" xml:space="preserve">
           <source>Kill</source>
-          <target state="new">Kill</target>
+          <target state="needs-review">Убийство</target>
         </trans-unit>
         <trans-unit id="BombDefusedEventName" translate="yes" xml:space="preserve">
           <source>of the bomb defused</source>
-          <target state="new">of the bomb defused</target>
+          <target state="needs-review">разминированной бомбы</target>
         </trans-unit>
         <trans-unit id="BombExplodedEventName" translate="yes" xml:space="preserve">
           <source>of the bomb exploded</source>
-          <target state="new">of the bomb exploded</target>
+          <target state="needs-review">взорванной бомбы</target>
         </trans-unit>
         <trans-unit id="BombPlantedEventName" translate="yes" xml:space="preserve">
           <source>of the bomb planted</source>
-          <target state="new">of the bomb planted</target>
+          <target state="needs-review">установленной бомбы</target>
           <note from="MultilingualBuild" annotates="source" priority="2">example: Set the tick of "the bomb planted"</note>
         </trans-unit>
         <trans-unit id="DecoyEventName" translate="yes" xml:space="preserve">
           <source>of the decoy</source>
-          <target state="new">of the decoy</target>
+          <target state="needs-review">отвлекающей гранаты</target>
         </trans-unit>
         <trans-unit id="FlashbangEventName" translate="yes" xml:space="preserve">
           <source>of the flashbang</source>
-          <target state="new">of the flashbang</target>
+          <target state="needs-review">световой гранаты</target>
         </trans-unit>
         <trans-unit id="HEEventName" translate="yes" xml:space="preserve">
           <source>of the HE</source>
-          <target state="new">of the HE</target>
+          <target state="needs-review">боевой гранаты</target>
         </trans-unit>
         <trans-unit id="Incendiary" translate="yes" xml:space="preserve">
           <source>Incendiary</source>
-          <target state="new">Incendiary</target>
+          <target state="needs-review">Зажигательная граната</target>
         </trans-unit>
         <trans-unit id="IncendiaryEventName" translate="yes" xml:space="preserve">
           <source>of the incendiary</source>
-          <target state="new">of the incendiary</target>
+          <target state="needs-review">зажигательной гранаты</target>
         </trans-unit>
         <trans-unit id="KillEventName" translate="yes" xml:space="preserve">
           <source>of the kill</source>
-          <target state="new">of the kill</target>
+          <target state="needs-review">убийства</target>
         </trans-unit>
         <trans-unit id="MolotovEventName" translate="yes" xml:space="preserve">
           <source>of the molotov</source>
-          <target state="new">of the molotov</target>
+          <target state="needs-review">коктейля Молотова</target>
         </trans-unit>
         <trans-unit id="Round" translate="yes" xml:space="preserve">
           <source>Round</source>
-          <target state="new">Round</target>
+          <target state="needs-review">Раунд</target>
         </trans-unit>
         <trans-unit id="SmokeEventName" translate="yes" xml:space="preserve">
           <source>of the smoke</source>
-          <target state="new">of the smoke</target>
+          <target state="needs-review">дымовой гранаты</target>
         </trans-unit>
         <trans-unit id="RoundEndEventName" translate="yes" xml:space="preserve">
           <source>of the round end</source>
-          <target state="new">of the round end</target>
+          <target state="needs-review">конца раунда</target>
         </trans-unit>
         <trans-unit id="RoundStartEventName" translate="yes" xml:space="preserve">
           <source>of the round start</source>
-          <target state="new">of the round start</target>
+          <target state="needs-review">начала раунда</target>
         </trans-unit>
         <trans-unit id="spec_player_lock" translate="yes" xml:space="preserve" extype="System.Resources.ResXFileRef, System.Windows.Forms">
           <source>..\resources\vdm\spec_player_lock.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</source>


### PR DESCRIPTION
Initial commit for russian translation (draft stage).
There are some problems.

Declension of some words. [Kills] in CSGODM is converted to [Убийства], in russian, but in app it should also be [Убийств, их]. There are much more. We need to decide if it's better to use a simple noun or a declension. Widely opened to discuss.

Another problem is compilation of app. I can't do it right now (even since i have spent a week to do a translation), i need help to build an app and check a lot of words i can't see in their positions. Some words are also have different declensions in different parts of the app and should be checked if it's normal for them to be there. It looks also that some of these words will be in exported files aswell. Need to triple check all this.

Some words are not translatable in a good manner. For example [tickrate] becoming [тикрейт] because of [частота тиков] and it's shortened [ЧТ] are not quite good for easy understanding. Another examples are ADR and KAST. I've translated em, but i can also see, that a lot of other languages are not translating them. I can connect it with the fact, that these abbreviations are already commonly used across any language and people are used to them. Also widely opened to discuss.

Feel free to add any comments and corrections!
Thank you all in advance!

Also to mention:
Lines 2798 and 2910 - supect (missing s)
Lines 887, 891, 1066 and 1070 - equipement (extra e)