### PR TITLE
fix(video): error when demo path contains spaces

### DIFF
--- a/src/node/counter-strike/launcher/watch-demo-with-hlae.ts
+++ b/src/node/counter-strike/launcher/watch-demo-with-hlae.ts
@@ -96,7 +96,7 @@ export async function watchDemoWithHlae({
   const csExecutablePath = await getCounterStrikeExecutablePath(game);
 
   const hlaeParameters: string[] = ['-noGui', '-autoStart'];
-  const launchOptions = ['-insecure', '-novid', '-sw', '+playdemo', `"${demoPath}"`];
+  const launchOptions = ['-insecure', '-novid', '-sw', '+playdemo', `\\"${demoPath}\\"`];
   if (width) {
     launchOptions.push('-width', String(width));
   }

--- a/src/node/video/ffmpeg/concatenate-videos-from-sequences.ts
+++ b/src/node/video/ffmpeg/concatenate-videos-from-sequences.ts
@@ -43,7 +43,7 @@ function getFfmpegArgs(options: ConcatenateVideoOptions) {
   }
   for (const sequence of sequences) {
     const sequenceOutputFilePath = getSequenceOutputFilePath(outputFolderPath, sequence);
-    args.push(`-i ${sequenceOutputFilePath}`);
+    args.push(`-i "${sequenceOutputFilePath}"`);
   }
   args.push(
     `-vcodec ${videoCodec} -pix_fmt yuv420p`,

--- a/src/node/video/ffmpeg/generate-video-with-ffmpeg.ts
+++ b/src/node/video/ffmpeg/generate-video-with-ffmpeg.ts
@@ -64,7 +64,7 @@ async function getFFmpegArgs(settings: GenerateVideoWithFFmpegSettings) {
   if (outputParameters !== '') {
     args.push(outputParameters);
   }
-  args.push(getSequenceOutputFilePath(outputFolderPath, sequence));
+  args.push('"' + getSequenceOutputFilePath(outputFolderPath, sequence) + '"');
 
   return args;
 }


### PR DESCRIPTION
Add escape characters for custom launch options in HLAE for paths with spaces.
Added quotes for FFMPEG arguments for paths with spaces.