### PR TITLE
fix: Change playback offset minSeconds to 0

### DIFF
--- a/src/ui/settings/playback/watch-before-kill-delay.tsx
+++ b/src/ui/settings/playback/watch-before-kill-delay.tsx
@@ -13,7 +13,7 @@ type Props = {
 
 export function WatchBeforeKillDelay({ title, description, defaultValue, onChange }: Props) {
   const _ = useI18n();
-  const minSeconds = 1;
+  const minSeconds = 0;
   const maxSeconds = 30;
 
   const onBlur = (event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Currently the default value for beforeRoundDelayInSeconds is 0 ([here](https://github.com/akiver/cs-demo-manager/blob/bea42abf9d98666545c087143d098d58d540a91e/src/node/settings/default-settings.ts#L57)). 

If this value gets changed, it cannot currently be set back to 0.