### PR TITLE
fix: output container 

### DIFF
--- a/src/node/video/ffmpeg/concatenate-videos-from-sequences.ts
+++ b/src/node/video/ffmpeg/concatenate-videos-from-sequences.ts
@@ -58,7 +58,7 @@ function getFfmpegArgs(options: ConcatenateVideoOptions) {
   if (outputParameters !== '') {
     args.push(outputParameters);
   }
-  args.push(`"${path.join(outputFolderPath, 'output.avi')}"`);
+  args.push(`"${path.join(outputFolderPath, `output.${videoContainer}`)}"`);
 
   return args;
 }


### PR DESCRIPTION
The output video container is always `output.avi` when the concatenate sequences into 1 video option is selected. 

I changed it so that the selected video container is used instead