### PR TITLE
feat: add persistent 2d viewer properties

### DIFF
--- a/src/ui/match/match-reducer.ts
+++ b/src/ui/match/match-reducer.ts
@@ -3,10 +3,12 @@ import { heatmapReducer } from 'csdm/ui/match/heatmap/heatmap-reducer';
 import { entityReducer } from 'csdm/ui/match/entity-reducer';
 import { videoReducer } from 'csdm/ui/match/video/video-reducer';
 import { grenadesReducer } from './grenades/grenades-reducer';
+import { viewer2DReducer } from './viewer-2d/viewer-2d-reducer';
 
 export const matchReducer = combineReducers({
   entity: entityReducer,
   heatmap: heatmapReducer,
   video: videoReducer,
   grenades: grenadesReducer,
+  viewer2D: viewer2DReducer,
 });

--- a/src/ui/match/viewer-2d/use-viewer-state.ts
+++ b/src/ui/match/viewer-2d/use-viewer-state.ts
@@ -1,0 +1,6 @@
+import { useSelector } from 'csdm/ui/store/use-selector';
+import type { Viewer2DState } from './viewer-2d-reducer';
+
+export function useViewer2DState(): Viewer2DState {
+  return useSelector((state) => state.match.viewer2D);
+}

--- a/src/ui/match/viewer-2d/viewer-2d-reducer.ts
+++ b/src/ui/match/viewer-2d/viewer-2d-reducer.ts
@@ -1,0 +1,26 @@
+import { createReducer } from '@reduxjs/toolkit';
+import { fetchMatchSuccess } from '../match-actions';
+import { focusedPlayerChanged, speedChanged } from './viewer-actions';
+
+export type Viewer2DState = {
+  speed: number;
+  focusedPlayerId: string | undefined;
+};
+
+const initialState: Viewer2DState = {
+  speed: 1,
+  focusedPlayerId: undefined,
+};
+
+export const viewer2DReducer = createReducer(initialState, (builder) => {
+  builder
+    .addCase(focusedPlayerChanged, (state, action) => {
+      state.focusedPlayerId = action.payload.focusedPlayerId;
+    })
+    .addCase(speedChanged, (state, action) => {
+      state.speed = action.payload.speed;
+    })
+    .addCase(fetchMatchSuccess, () => {
+      return initialState;
+    });
+});

--- a/src/ui/match/viewer-2d/viewer-actions.ts
+++ b/src/ui/match/viewer-2d/viewer-actions.ts
@@ -1,0 +1,6 @@
+import { createAction } from '@reduxjs/toolkit';
+
+export const focusedPlayerChanged = createAction<{ focusedPlayerId: string | undefined }>(
+  'match/viewer/focusedPlayerChanged',
+);
+export const speedChanged = createAction<{ speed: number }>('match/viewer/speedChanged');

--- a/src/ui/match/viewer-2d/viewer-context.tsx
+++ b/src/ui/match/viewer-2d/viewer-context.tsx
@@ -25,6 +25,9 @@ import type { SmokeStart } from 'csdm/common/types/smoke-start';
 import type { HeGrenadeExplode } from 'csdm/common/types/he-grenade-explode';
 import type { FlashbangExplode } from 'csdm/common/types/flashbang-explode';
 import type { Game } from 'csdm/common/types/counter-strike';
+import { useDispatch } from 'csdm/ui/store/use-dispatch';
+import { focusedPlayerChanged, speedChanged } from './viewer-actions';
+import { useViewer2DState } from './use-viewer-state';
 
 type ViewerContext = {
   framerate: number;
@@ -112,11 +115,11 @@ export function ViewerProvider({
   smokesStart,
   flashbangsExplode,
 }: Props) {
+  const dispatch = useDispatch();
   const match = useCurrentMatch();
-  const [speed, setSpeed] = useState(1);
+  const viewerState = useViewer2DState();
   const [currentFrame, setCurrentFrame] = useState(round.freezetimeEndFrame);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [focusedPlayerId, setFocusedPlayerId] = useState<string | undefined>(undefined);
   const [radarLevel, setRadarLevel] = useState<RadarLevel>(RadarLevel.Upper);
   const remainingFrameCount = round.endOfficiallyFrame - currentFrame;
   const frameRate = match.frameRate > 0 ? match.frameRate : match.tickrate / 2;
@@ -127,11 +130,6 @@ export function ViewerProvider({
     <ViewerContext.Provider
       value={{
         framerate: frameRate,
-        focusedPlayerId,
-        updateFocusedPlayerId: (id: string) => {
-          const newId = id === focusedPlayerId ? undefined : id;
-          setFocusedPlayerId(newId);
-        },
         setRadarLevel,
         radarLevel,
         map,
@@ -155,15 +153,22 @@ export function ViewerProvider({
         currentFrame,
         setCurrentFrame,
         timeRemaining,
-        speed,
         isPlaying,
-        setSpeed,
         setIsPlaying,
         kills,
         shots,
         round,
         changeRound: (roundNumber: number) => {
           navigate(buildMatch2dViewerRoundPath(match.checksum, roundNumber));
+        },
+        speed: viewerState.speed,
+        setSpeed: (speed: number) => {
+          dispatch(speedChanged({ speed }));
+        },
+        focusedPlayerId: viewerState.focusedPlayerId,
+        updateFocusedPlayerId: (id: string) => {
+          const newId = id === viewerState.focusedPlayerId ? undefined : id;
+          dispatch(focusedPlayerChanged({ focusedPlayerId: newId }));
         },
       }}
     >

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -178,7 +178,8 @@ const config: Config = {
           '-webkit-user-drag': 'none',
         },
         '.appearance-v-slider': {
-          'writing-mode': 'vertical-rl',
+          'writing-mode': 'vertical-lr',
+          'direction': 'rtl',
         },
         '.scrollbar-stable': {
           'scrollbar-gutter': 'stable',


### PR DESCRIPTION
Made 2 quality of life changes for the 2d demo viewer:

In the first commit I added a new redux reducer to save the focused player & speed states. This makes it so those properties do not need to be reset every time a new round loads. The saved values are cleared when a new match is opened.

In the second commit I flipped the direction of the speed slider so that pulling it up increases the value. This is a more standard user experience for sliders.

Old Behavior:
![saveOld](https://github.com/akiver/cs-demo-manager/assets/25374806/48ce2e5c-21a6-434e-9930-ea689021e2d5)

New Behavior: 
![saveNew](https://github.com/akiver/cs-demo-manager/assets/25374806/ae3b160c-5153-4988-bd1b-45d91adb17bf)
