### PR TITLE
feat(playback): add CS2 aliases to listen to specific team/player's v…

### DIFF
--- a/src/common/types/player-slot.ts
+++ b/src/common/types/player-slot.ts
@@ -1,1 +1,0 @@
-export type PlayerSlot = { [steamId: string]: number };

--- a/src/common/types/player-watch-info.ts
+++ b/src/common/types/player-watch-info.ts
@@ -1,0 +1,8 @@
+import type { TeamNumber } from './counter-strike';
+
+export type PlayerWatchInfo = {
+  steamId: string;
+  slot: number;
+  userId: number;
+  side: TeamNumber;
+};

--- a/src/node/counter-strike/json-actions-file/__snapshots__/generate-player-lowlights-json-file.test.ts.snap
+++ b/src/node/counter-strike/json-actions-file/__snapshots__/generate-player-lowlights-json-file.test.ts.snap
@@ -13,6 +13,14 @@ exports[`Generate player's lowlights JSON file > CS2 1`] = `
         "tick": 64
       },
       {
+        "cmd": "alias \\"voice_all\\" \\"tv_listen_voice_indices -1; tv_listen_voice_indices_h -1; echo Listening to all players\\"",
+        "tick": 64
+      },
+      {
+        "cmd": "echo \\"[CSDM] Type voice_all to listen to all players\\"",
+        "tick": 64
+      },
+      {
         "cmd": "demo_gototick 872",
         "tick": 64
       },

--- a/src/node/counter-strike/json-actions-file/__snapshots__/generate-player-rounds-json-file.test.ts.snap
+++ b/src/node/counter-strike/json-actions-file/__snapshots__/generate-player-rounds-json-file.test.ts.snap
@@ -13,6 +13,14 @@ exports[`Generate player's rounds JSON file > CS2 1`] = `
         "tick": 64
       },
       {
+        "cmd": "alias \\"voice_all\\" \\"tv_listen_voice_indices -1; tv_listen_voice_indices_h -1; echo Listening to all players\\"",
+        "tick": 64
+      },
+      {
+        "cmd": "echo \\"[CSDM] Type voice_all to listen to all players\\"",
+        "tick": 64
+      },
+      {
         "cmd": "demo_gototick 872",
         "tick": 64
       },

--- a/src/node/counter-strike/json-actions-file/generate-player-lowlights-json-file.test.ts
+++ b/src/node/counter-strike/json-actions-file/generate-player-lowlights-json-file.test.ts
@@ -62,6 +62,7 @@ describe(`Generate player's lowlights JSON file`, () => {
       beforeDelaySeconds: 2,
       nextDelaySeconds: 4,
       playerVoicesEnabled: true,
+      players: [],
     });
 
     const content = await fs.readFile(`${demoPath}.json`, 'utf8');
@@ -123,6 +124,7 @@ describe(`Generate player's lowlights JSON file`, () => {
       beforeDelaySeconds: 2,
       nextDelaySeconds: 4,
       playerVoicesEnabled: true,
+      players: [],
     });
 
     const content = await fs.readFile(`${demoPath}.json`, 'utf8');

--- a/src/node/counter-strike/json-actions-file/generate-player-lowlights-json-file.ts
+++ b/src/node/counter-strike/json-actions-file/generate-player-lowlights-json-file.ts
@@ -2,6 +2,7 @@ import { Perspective } from 'csdm/common/types/perspective';
 import type { Action } from 'csdm/node/database/watch/get-match-playback';
 import { JSONActionsFileGenerator } from './json-actions-file-generator';
 import { Game } from 'csdm/common/types/counter-strike';
+import type { PlayerWatchInfo } from 'csdm/common/types/player-watch-info';
 
 function getSteamIdToFocusFromAction(isPlayerPerspective: boolean, action: Action) {
   return isPlayerPerspective
@@ -29,6 +30,7 @@ type Parameters = {
   beforeDelaySeconds: number;
   nextDelaySeconds: number;
   playerVoicesEnabled: boolean;
+  players: PlayerWatchInfo[];
 };
 
 export async function generatePlayerLowlightsJsonFile({
@@ -41,6 +43,7 @@ export async function generatePlayerLowlightsJsonFile({
   beforeDelaySeconds,
   nextDelaySeconds,
   playerVoicesEnabled,
+  players,
 }: Parameters) {
   const json = new JSONActionsFileGenerator(demoPath, game);
 
@@ -49,6 +52,8 @@ export async function generatePlayerLowlightsJsonFile({
   } else {
     json.disablePlayerVoices();
   }
+
+  json.generateVoiceAliases(players);
 
   if (nextDelaySeconds < 1) {
     nextDelaySeconds = 1;

--- a/src/node/counter-strike/json-actions-file/generate-player-rounds-json-file.test.ts
+++ b/src/node/counter-strike/json-actions-file/generate-player-rounds-json-file.test.ts
@@ -45,6 +45,7 @@ describe(`Generate player's rounds JSON file`, () => {
       afterDelaySeconds: 6,
       game: Game.CSGO,
       playerVoicesEnabled: true,
+      players: [],
     });
 
     const content = await fs.readFile(`${demoPath}.json`, 'utf8');
@@ -90,6 +91,7 @@ describe(`Generate player's rounds JSON file`, () => {
       afterDelaySeconds: 6,
       game: Game.CS2,
       playerVoicesEnabled: true,
+      players: [],
     });
 
     const content = await fs.readFile(`${demoPath}.json`, 'utf8');

--- a/src/node/counter-strike/json-actions-file/generate-player-rounds-json-file.ts
+++ b/src/node/counter-strike/json-actions-file/generate-player-rounds-json-file.ts
@@ -1,12 +1,14 @@
 import type { Game } from 'csdm/common/types/counter-strike';
 import type { Round } from '../launcher/watch-player-rounds';
 import { JSONActionsFileGenerator } from './json-actions-file-generator';
+import type { PlayerWatchInfo } from 'csdm/common/types/player-watch-info';
 
 type Options = {
   tickrate: number;
   demoPath: string;
   game: Game;
   rounds: Round[];
+  players: PlayerWatchInfo[];
   playerId: number | string;
   beforeDelaySeconds: number;
   afterDelaySeconds: number;
@@ -18,6 +20,7 @@ export async function generatePlayerRoundsJsonFile({
   demoPath,
   game,
   rounds,
+  players,
   playerId,
   beforeDelaySeconds,
   afterDelaySeconds,
@@ -30,6 +33,8 @@ export async function generatePlayerRoundsJsonFile({
   } else {
     json.disablePlayerVoices();
   }
+
+  json.generateVoiceAliases(players);
 
   const beforeRoundTicks = beforeDelaySeconds > 0 ? beforeDelaySeconds * tickrate : 128;
   const afterRoundTicks = afterDelaySeconds > 0 ? afterDelaySeconds * tickrate : tickrate;

--- a/src/node/counter-strike/json-actions-file/output/cs2-player-lowlights.dem.json
+++ b/src/node/counter-strike/json-actions-file/output/cs2-player-lowlights.dem.json
@@ -10,6 +10,14 @@
         "tick": 64
       },
       {
+        "cmd": "alias \"voice_all\" \"tv_listen_voice_indices -1; tv_listen_voice_indices_h -1; echo Listening to all players\"",
+        "tick": 64
+      },
+      {
+        "cmd": "echo \"[CSDM] Type voice_all to listen to all players\"",
+        "tick": 64
+      },
+      {
         "cmd": "demo_gototick 872",
         "tick": 64
       },

--- a/src/node/counter-strike/json-actions-file/output/cs2-player-rounds.dem.json
+++ b/src/node/counter-strike/json-actions-file/output/cs2-player-rounds.dem.json
@@ -10,6 +10,14 @@
         "tick": 64
       },
       {
+        "cmd": "alias \"voice_all\" \"tv_listen_voice_indices -1; tv_listen_voice_indices_h -1; echo Listening to all players\"",
+        "tick": 64
+      },
+      {
+        "cmd": "echo \"[CSDM] Type voice_all to listen to all players\"",
+        "tick": 64
+      },
+      {
         "cmd": "demo_gototick 872",
         "tick": 64
       },

--- a/src/node/counter-strike/launcher/watch-demo.ts
+++ b/src/node/counter-strike/launcher/watch-demo.ts
@@ -6,7 +6,7 @@ import { getSettings } from 'csdm/node/settings/get-settings';
 import { watchDemoWithHlae } from './watch-demo-with-hlae';
 import { getDemoChecksumFromDemoPath } from 'csdm/node/demo/get-demo-checksum-from-demo-path';
 import { fetchMatchPlayersSlots } from 'csdm/node/database/match/fetch-match-players-slots';
-import type { Game } from 'csdm/common/types/counter-strike';
+import { Game } from 'csdm/common/types/counter-strike';
 
 async function generateJsonActionsFile(
   demoPath: string,
@@ -27,12 +27,17 @@ async function generateJsonActionsFile(
     json.addSkipAhead(0, startTick);
   }
 
-  if (steamId !== undefined) {
+  if (steamId || game !== Game.CSGO) {
     const checksum = await getDemoChecksumFromDemoPath(demoPath);
-    const slots = await fetchMatchPlayersSlots(checksum);
-    const slot = slots[steamId];
-    if (slot) {
-      json.addSpecPlayer(startTick ?? 0, slot);
+    const players = await fetchMatchPlayersSlots(checksum);
+    if (game !== Game.CSGO) {
+      json.generateVoiceAliases(players);
+    }
+    if (steamId) {
+      const player = players.find((player) => player.steamId === steamId);
+      if (player) {
+        json.addSpecPlayer(startTick ?? 0, player.slot);
+      }
     }
   }
 

--- a/src/node/counter-strike/launcher/watch-player-lowlights.ts
+++ b/src/node/counter-strike/launcher/watch-player-lowlights.ts
@@ -10,6 +10,7 @@ import { deleteJsonActionsFile } from '../json-actions-file/delete-json-actions-
 import { generatePlayerLowlightsJsonFile } from '../json-actions-file/generate-player-lowlights-json-file';
 import { watchDemoWithHlae } from './watch-demo-with-hlae';
 import { assertPlayersSlotsAreDefined } from './assert-players-slots-are-defined';
+import { fetchMatchPlayersSlots } from 'csdm/node/database/match/fetch-match-players-slots';
 
 function assertPlayerHasActions(match: PlaybackMatch) {
   if (match.actions.length === 0) {
@@ -48,6 +49,7 @@ export async function watchPlayerLowlights({ demoPath, steamId, perspective, onG
           beforeDelaySeconds: lowlights.beforeKillDelayInSeconds,
           nextDelaySeconds: lowlights.afterKillDelayInSeconds,
           playerVoicesEnabled,
+          players: [],
         });
       }
     } else {
@@ -61,6 +63,7 @@ export async function watchPlayerLowlights({ demoPath, steamId, perspective, onG
 
     assertPlayerHasActions(match);
     assertPlayersSlotsAreDefined(match.actions);
+    const players = await fetchMatchPlayersSlots(match.checksum);
 
     await generatePlayerLowlightsJsonFile({
       actions: match.actions,
@@ -72,6 +75,7 @@ export async function watchPlayerLowlights({ demoPath, steamId, perspective, onG
       beforeDelaySeconds: lowlights.beforeKillDelayInSeconds,
       nextDelaySeconds: lowlights.afterKillDelayInSeconds,
       playerVoicesEnabled,
+      players,
     });
   }
 

--- a/src/node/database/match/fetch-match-players-slots.ts
+++ b/src/node/database/match/fetch-match-players-slots.ts
@@ -1,17 +1,29 @@
-import type { PlayerSlot } from 'csdm/common/types/player-slot';
+import type { PlayerWatchInfo } from 'csdm/common/types/player-watch-info';
 import { db } from '../database';
 
-export async function fetchMatchPlayersSlots(checksum: string): Promise<PlayerSlot> {
+export async function fetchMatchPlayersSlots(checksum: string): Promise<PlayerWatchInfo[]> {
   const rows = await db
-    .selectFrom('players')
-    .select(['players.steam_id', 'players.index as slot'])
-    .where('players.match_checksum', '=', checksum)
+    .selectFrom('matches')
+    .innerJoin('players', (qb) => {
+      return qb.onRef('players.match_checksum', '=', 'matches.checksum');
+    })
+    .innerJoin('teams', (qb) => {
+      return qb
+        .onRef('teams.match_checksum', '=', 'players.match_checksum')
+        .onRef('teams.name', '=', 'players.team_name');
+    })
+    .select(['players.steam_id', 'players.index as slot', 'teams.current_side as side'])
+    .where('matches.checksum', '=', checksum)
     .execute();
 
-  const slots: PlayerSlot = {};
-  for (const row of rows) {
-    slots[row.steam_id] = row.slot;
-  }
+  const players: PlayerWatchInfo[] = rows.map((row) => {
+    return {
+      steamId: row.steam_id,
+      side: row.side,
+      slot: row.slot,
+      userId: row.slot - 1, // The player slot is the user id + 1 in demos.
+    };
+  });
 
-  return slots;
+  return players;
 }

--- a/src/node/video/generate-video.ts
+++ b/src/node/video/generate-video.ts
@@ -209,14 +209,14 @@ export async function generateVideo(parameters: Parameters) {
       tickrate,
     });
   } else {
-    const playerSlots = await fetchMatchPlayersSlots(parameters.checksum);
+    const players = await fetchMatchPlayersSlots(parameters.checksum);
     await createCs2JsonActionsFileForRecording({
       framerate,
       demoPath,
       sequences,
       closeGameAfterRecording,
       tickrate,
-      playerSlots,
+      players,
     });
   }
 

--- a/src/ui/translations/es/messages.po
+++ b/src/ui/translations/es/messages.po
@@ -16,6 +16,7 @@ msgstr ""
 "X-Crowdin-Language: es-ES\n"
 "X-Crowdin-File: /src/ui/translations/en/messages.po\n"
 "X-Crowdin-File-ID: 198\n"
+"PO-Revision-Date: \n"
 
 #: src/ui/analyses/action-bar/remove-all-analyses-button.tsx
 msgid "Remove all"

--- a/src/ui/translations/fr/messages.po
+++ b/src/ui/translations/fr/messages.po
@@ -16,6 +16,7 @@ msgstr ""
 "X-Crowdin-Language: fr\n"
 "X-Crowdin-File: /src/ui/translations/en/messages.po\n"
 "X-Crowdin-File-ID: 198\n"
+"PO-Revision-Date: \n"
 
 #: src/ui/analyses/action-bar/remove-all-analyses-button.tsx
 msgid "Remove all"

--- a/src/ui/translations/pt-BR/messages.po
+++ b/src/ui/translations/pt-BR/messages.po
@@ -16,6 +16,7 @@ msgstr ""
 "X-Crowdin-Language: pt-BR\n"
 "X-Crowdin-File: /src/ui/translations/en/messages.po\n"
 "X-Crowdin-File-ID: 198\n"
+"PO-Revision-Date: \n"
 
 #: src/ui/analyses/action-bar/remove-all-analyses-button.tsx
 msgid "Remove all"

--- a/src/ui/translations/zh-CN/messages.po
+++ b/src/ui/translations/zh-CN/messages.po
@@ -16,6 +16,7 @@ msgstr ""
 "X-Crowdin-Language: zh-CN\n"
 "X-Crowdin-File: /src/ui/translations/en/messages.po\n"
 "X-Crowdin-File-ID: 198\n"
+"PO-Revision-Date: \n"
 
 #: src/ui/analyses/action-bar/remove-all-analyses-button.tsx
 msgid "Remove all"

--- a/src/ui/translations/zh-TW/messages.po
+++ b/src/ui/translations/zh-TW/messages.po
@@ -16,6 +16,7 @@ msgstr ""
 "X-Crowdin-Language: zh-TW\n"
 "X-Crowdin-File: /src/ui/translations/en/messages.po\n"
 "X-Crowdin-File-ID: 198\n"
+"PO-Revision-Date: \n"
 
 #: src/ui/analyses/action-bar/remove-all-analyses-button.tsx
 msgid "Remove all"


### PR DESCRIPTION
feat(playback): add CS2 aliases to listen to specific team/player's voices

- `voice_all`: Listen to all players
- `voice_ct`: Listen to players that STARTED as CT
- `voice_t`: Listen to players that STARTED as T
- `voice_STEAMID64`: Listen to player's voice identified by SteamID64

It's important to note that for teams aliases it's the starting side, not the current side while watching the demo.

ref https://github.com/akiver/cs-demo-manager/discussions/1026