### PR TITLE
fix translation for zh

### DIFF
--- a/src/ui/translations/zh-CN/messages.po
+++ b/src/ui/translations/zh-CN/messages.po
@@ -4019,7 +4019,7 @@ msgstr "查找"
 #: src/ui/match/grenades/stats/grenade-select.tsx
 msgctxt "Grenade name"
 msgid "Fire"
-msgstr "开火"
+msgstr "燃烧弹"
 
 #: src/ui/match/grenades/stats/labels/fire-labels.tsx
 #: src/ui/match/grenades/stats/labels/he-grenade-labels.tsx


### PR DESCRIPTION
"开火" in chinese means shooting rather than Molotovs or Incendiaries. may translate it as verb?

![image](https://github.com/user-attachments/assets/f77a0e88-5d42-4a6c-bda6-480602c9a155)

its here