### PR TITLE
feat(cli): add more arguments to video command

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -121,7 +121,7 @@ async function buildCliBundle() {
       'process.env.STEAM_API_KEYS': `"${process.env.STEAM_API_KEYS}"`,
       'process.env.FACEIT_API_KEY': `"${process.env.FACEIT_API_KEY}"`,
     },
-    external: ['pg-native'],
+    external: ['pg-native', '@aws-sdk/client-s3'],
     plugins: [nativeNodeModulesPlugin],
   });
 }

--- a/scripts/develop-cli.mjs
+++ b/scripts/develop-cli.mjs
@@ -26,6 +26,8 @@ const context = await esbuild.context({
   external: [
     'pg-native',
     '@aws-sdk/client-s3', // the unzipper module has it as a dev dependency
+    'registry-js',
+    'fdir',
   ],
   plugins: [nativeNodeModulesPlugin],
 });

--- a/scripts/develop-cli.mjs
+++ b/scripts/develop-cli.mjs
@@ -26,8 +26,6 @@ const context = await esbuild.context({
   external: [
     'pg-native',
     '@aws-sdk/client-s3', // the unzipper module has it as a dev dependency
-    'registry-js',
-    'fdir',
   ],
   plugins: [nativeNodeModulesPlugin],
 });

--- a/src/cli/commands/video-command.ts
+++ b/src/cli/commands/video-command.ts
@@ -78,6 +78,7 @@ export class VideoCommand extends Command {
 
   public async run() {
     try {
+      await this.initDatabaseConnection();
       this.parseArgs();
       await migrateSettings();
 

--- a/src/cli/commands/video-command.ts
+++ b/src/cli/commands/video-command.ts
@@ -12,15 +12,15 @@ import type { RecordingSystem } from 'csdm/common/types/recording-system';
 import { RecordingSystem as RecordingSystemEnum } from 'csdm/common/types/recording-system';
 import type { RecordingOutput } from 'csdm/common/types/recording-output';
 import { RecordingOutput as RecordingOutputEnum } from 'csdm/common/types/recording-output';
-import type { VideoContainer } from 'csdm/common/types/video-container';
+import { VideoContainer } from 'csdm/common/types/video-container';
 import { parseArgs } from 'node:util';
 import { InvalidArgument } from 'csdm/node/errors/invalid-argument';
 
 export class VideoCommand extends Command {
   public static Name = 'video';
-  private demoPath: string;
-  private startTick: number;
-  private endTick: number;
+  private demoPath: string = '';
+  private startTick: number = 0;
+  private endTick: number = 0;
   private framerate: number | undefined;
   private width: number | undefined;
   private height: number | undefined;
@@ -80,12 +80,11 @@ export class VideoCommand extends Command {
     try {
       this.parseArgs();
       await migrateSettings();
-      await this.initDatabaseConnection();
 
       const settings = await getSettings();
       const demo = await getDemoFromFilePath(this.demoPath);
       let outputFolderPath = await getOutputFolderPath(settings.video, this.demoPath);
-      outputFolderPath = `${outputFolderPath}/${demo.name}`
+      outputFolderPath = `${outputFolderPath}/${demo.name}`;
 
       const sequence: Sequence = {
         number: 1,
@@ -281,7 +280,11 @@ export class VideoCommand extends Command {
       this.ffmpegAudioCodec = String(values['ffmpeg-audio-codec']);
     }
     if (values['ffmpeg-video-container'] !== undefined) {
-      this.ffmpegVideoContainer = String(values['ffmpeg-video-container']);
+      const videoContainer = values['ffmpeg-video-container'] as VideoContainer;
+      if (!Object.values(VideoContainer).includes(videoContainer)) {
+        throw new InvalidArgument('Invalid video container');
+      }
+      this.ffmpegVideoContainer = videoContainer;
     }
     if (values['ffmpeg-input-parameters'] !== undefined) {
       this.ffmpegInputParameters = String(values['ffmpeg-input-parameters']);

--- a/src/node/errors/invalid-argument.ts
+++ b/src/node/errors/invalid-argument.ts
@@ -1,0 +1,6 @@
+export class InvalidArgument extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidArgument';
+  }
+}


### PR DESCRIPTION
This change adds more arguments to the video command to allow users to customize the video generation process from the command line. The new arguments include options for framerate, resolution, encoder, and other settings available in the UI.

