### PR TITLE
feat(chat): export chat messages by player

### DIFF
--- a/src/node/chat-messages/export-match-chat-messages.ts
+++ b/src/node/chat-messages/export-match-chat-messages.ts
@@ -10,13 +10,9 @@ export async function exportMatchChatMessages(
 ) {
   let chatMessages: ChatMessage[];
   if (!messages) {
-    chatMessages = await fetchChatMessages(checksum);
+    chatMessages = await fetchChatMessages(checksum, steamIds);
   } else {
     chatMessages = messages;
-  }
-
-  if (steamIds !== undefined && steamIds.length > 0) {
-    chatMessages = chatMessages.filter((chatMessage) => steamIds.includes(chatMessage.senderSteamId));
   }
 
   return await writeChatMessagesToFile(chatMessages, filePath);

--- a/src/node/chat-messages/export-match-chat-messages.ts
+++ b/src/node/chat-messages/export-match-chat-messages.ts
@@ -11,6 +11,8 @@ export async function exportMatchChatMessages(
   let chatMessages: ChatMessage[];
   if (!messages) {
     chatMessages = await fetchChatMessages(checksum, steamIds);
+  } else if (Array.isArray(steamIds) && steamIds.length > 0) {
+    chatMessages = messages.filter((chatMessage) => steamIds.includes(chatMessage.senderSteamId));
   } else {
     chatMessages = messages;
   }

--- a/src/node/chat-messages/export-match-chat-messages.ts
+++ b/src/node/chat-messages/export-match-chat-messages.ts
@@ -2,12 +2,21 @@ import { fetchChatMessages } from '../database/chat-messages/fetch-chat-messages
 import { writeChatMessagesToFile } from './write-chat-messages-to-file';
 import type { ChatMessage } from 'csdm/common/types/chat-message';
 
-export async function exportMatchChatMessages(checksum: string, filePath: string, messages?: ChatMessage[]) {
+export async function exportMatchChatMessages(
+  checksum: string,
+  filePath: string,
+  messages?: ChatMessage[],
+  steamIds?: string[],
+) {
   let chatMessages: ChatMessage[];
   if (!messages) {
     chatMessages = await fetchChatMessages(checksum);
   } else {
     chatMessages = messages;
+  }
+
+  if (steamIds !== undefined && steamIds.length > 0) {
+    chatMessages = chatMessages.filter((chatMessage) => steamIds.includes(chatMessage.senderSteamId));
   }
 
   return await writeChatMessagesToFile(chatMessages, filePath);

--- a/src/node/chat-messages/export-matches-chat-messages.ts
+++ b/src/node/chat-messages/export-matches-chat-messages.ts
@@ -4,16 +4,12 @@ import { writeChatMessagesToFile } from './write-chat-messages-to-file';
 
 export async function exportMatchesChatMessages(checksums: string[], outputFolder: string, steamIds?: string[]) {
   let hasExportedAtLeastOneMatch = false;
-  const shouldFilterByPlayers = steamIds !== undefined && steamIds.length > 0;
 
   await Promise.all(
     checksums.map(async (checksum) => {
-      const messages = await fetchChatMessages(checksum);
-      const filteredMessages = shouldFilterByPlayers
-        ? messages.filter((message) => steamIds.includes(message.senderSteamId))
-        : messages;
+      const messages = await fetchChatMessages(checksum, steamIds);
       const filePath = path.join(outputFolder, `messages-${checksum}.txt`);
-      const hasWrittenFile = await writeChatMessagesToFile(filteredMessages, filePath);
+      const hasWrittenFile = await writeChatMessagesToFile(messages, filePath);
       if (hasWrittenFile) {
         hasExportedAtLeastOneMatch = true;
       }

--- a/src/node/chat-messages/export-matches-chat-messages.ts
+++ b/src/node/chat-messages/export-matches-chat-messages.ts
@@ -2,14 +2,18 @@ import { fetchChatMessages } from '../database/chat-messages/fetch-chat-messages
 import path from 'node:path';
 import { writeChatMessagesToFile } from './write-chat-messages-to-file';
 
-export async function exportMatchesChatMessages(checksums: string[], outputFolder: string) {
+export async function exportMatchesChatMessages(checksums: string[], outputFolder: string, steamIds?: string[]) {
   let hasExportedAtLeastOneMatch = false;
+  const shouldFilterByPlayers = steamIds !== undefined && steamIds.length > 0;
 
   await Promise.all(
     checksums.map(async (checksum) => {
       const messages = await fetchChatMessages(checksum);
+      const filteredMessages = shouldFilterByPlayers
+        ? messages.filter((message) => steamIds.includes(message.senderSteamId))
+        : messages;
       const filePath = path.join(outputFolder, `messages-${checksum}.txt`);
-      const hasWrittenFile = await writeChatMessagesToFile(messages, filePath);
+      const hasWrittenFile = await writeChatMessagesToFile(filteredMessages, filePath);
       if (hasWrittenFile) {
         hasExportedAtLeastOneMatch = true;
       }

--- a/src/node/database/chat-messages/fetch-chat-messages.ts
+++ b/src/node/database/chat-messages/fetch-chat-messages.ts
@@ -2,14 +2,19 @@ import type { ChatMessage } from 'csdm/common/types/chat-message';
 import { db } from 'csdm/node/database/database';
 import { chatMessageRowToChatMessage } from './chat-message-row-to-chat-message';
 
-export async function fetchChatMessages(checksum: string): Promise<ChatMessage[]> {
-  const rows = await db
+export async function fetchChatMessages(checksum: string, steamIds?: string[]): Promise<ChatMessage[]> {
+  let query = db
     .selectFrom('chat_messages')
     .selectAll()
     .leftJoin('steam_account_overrides', 'chat_messages.sender_steam_id', 'steam_account_overrides.steam_id')
     .select([db.fn.coalesce('steam_account_overrides.name', 'chat_messages.sender_name').as('sender_name')])
-    .where('match_checksum', '=', checksum)
-    .execute();
+    .where('match_checksum', '=', checksum);
+
+  if (Array.isArray(steamIds) && steamIds.length > 0) {
+    query = query.where('chat_messages.sender_steam_id', 'in', steamIds);
+  }
+
+  const rows = await query.execute();
   const chatMessages: ChatMessage[] = rows.map((row) => {
     return chatMessageRowToChatMessage(row);
   });

--- a/src/server/handlers/renderer-process/match/export-match-chat-messages-handler.ts
+++ b/src/server/handlers/renderer-process/match/export-match-chat-messages-handler.ts
@@ -7,11 +7,17 @@ export type ExportChatMessagesPayload = {
   checksum: string;
   filePath: string;
   messages?: ChatMessage[];
+  steamIds?: string[];
 };
 
-export async function exportMatchChatMessagesHandler({ checksum, filePath, messages }: ExportChatMessagesPayload) {
+export async function exportMatchChatMessagesHandler({
+  checksum,
+  filePath,
+  messages,
+  steamIds,
+}: ExportChatMessagesPayload) {
   try {
-    return await exportMatchChatMessages(checksum, filePath, messages);
+    return await exportMatchChatMessages(checksum, filePath, messages, steamIds);
   } catch (error) {
     handleError(error, 'Error while exporting chat messages');
   }

--- a/src/server/handlers/renderer-process/match/export-matches-chat-messages-handler.ts
+++ b/src/server/handlers/renderer-process/match/export-matches-chat-messages-handler.ts
@@ -1,14 +1,19 @@
 import { exportMatchesChatMessages } from 'csdm/node/chat-messages/export-matches-chat-messages';
 import { handleError } from '../../handle-error';
 
-export type ExportMatchesChatMessagesPayload = { outputFolderPath: string; checksums: string[] };
+export type ExportMatchesChatMessagesPayload = {
+  outputFolderPath: string;
+  checksums: string[];
+  steamIds?: string[];
+};
 
 export async function exportMatchesChatMessagesHandler({
   checksums,
   outputFolderPath,
+  steamIds,
 }: ExportMatchesChatMessagesPayload) {
   try {
-    return await exportMatchesChatMessages(checksums, outputFolderPath);
+    return await exportMatchesChatMessages(checksums, outputFolderPath, steamIds);
   } catch (error) {
     handleError(error, 'Error while exporting matches chat messages');
   }

--- a/src/ui/components/context-menu/items/export-chat-messages-item.tsx
+++ b/src/ui/components/context-menu/items/export-chat-messages-item.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { ContextMenuItem } from 'csdm/ui/components/context-menu/context-menu-item';
 import { useWebSocketClient } from 'csdm/ui/hooks/use-web-socket-client';
@@ -6,20 +6,77 @@ import { useShowToast } from '../../toasts/use-show-toast';
 import { RendererClientMessageName } from 'csdm/server/renderer-client-message-name';
 import type { ExportMatchesChatMessagesPayload } from 'csdm/server/handlers/renderer-process/match/export-matches-chat-messages-handler';
 import { useExportMatchChatMessages } from 'csdm/ui/hooks/use-export-match-chat-messages';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from 'csdm/ui/dialogs/dialog';
+import { useDialog } from 'csdm/ui/components/dialogs/use-dialog';
+import { Button } from 'csdm/ui/components/buttons/button';
+import { ConfirmButton } from 'csdm/ui/components/buttons/confirm-button';
+import { CancelButton } from 'csdm/ui/components/buttons/cancel-button';
+import { PlayersSelect } from '../../inputs/select/players-select';
+import type { MatchTablePlayer } from 'csdm/common/types/match-table';
+
+type SelectPlayersDialogProps = {
+  players: MatchTablePlayer[];
+  onConfirm: (steamIds: string[]) => void;
+};
+
+function SelectPlayersDialog({ players, onConfirm }: SelectPlayersDialogProps) {
+  const { hideDialog } = useDialog();
+  const [steamIds, setSteamIds] = useState<string[]>([]);
+
+  return (
+    <Dialog>
+      <div className="w-[768px]">
+        <DialogHeader>
+          <DialogTitle>
+            <Trans>Chat messages export</Trans>
+          </DialogTitle>
+        </DialogHeader>
+        <DialogContent>
+          <div className="flex flex-col gap-y-8">
+            <p>
+              <Trans>Select the players whose chat messages you want to export.</Trans>
+            </p>
+            <div className="max-h-[220px] overflow-auto">
+              <PlayersSelect players={players} selectedSteamIds={steamIds} onChange={setSteamIds} filter={null} />
+            </div>
+          </div>
+        </DialogContent>
+        <DialogFooter>
+          <Button
+            onClick={() => {
+              onConfirm([]);
+            }}
+          >
+            <Trans context="Button">Export all players</Trans>
+          </Button>
+          <ConfirmButton
+            onClick={() => {
+              onConfirm(steamIds);
+            }}
+            isDisabled={steamIds.length === 0}
+          />
+          <CancelButton onClick={hideDialog} />
+        </DialogFooter>
+      </div>
+    </Dialog>
+  );
+}
 
 type Props = {
   checksums: string[];
+  players?: MatchTablePlayer[];
 };
 
-export function ExportChatMessagesItem({ checksums }: Props) {
+export function ExportChatMessagesItem({ checksums, players }: Props) {
   const { t } = useLingui();
   const client = useWebSocketClient();
   const showToast = useShowToast();
   const exportChatMessages = useExportMatchChatMessages();
+  const { showDialog, hideDialog } = useDialog();
 
-  const onClick = async () => {
+  const exportChatMessagesForSteamIds = async (steamIds: string[]) => {
     if (checksums.length === 1) {
-      return exportChatMessages(checksums[0]);
+      return exportChatMessages(checksums[0], undefined, steamIds);
     }
 
     const { filePaths, canceled } = await window.csdm.showOpenDialog({
@@ -40,6 +97,7 @@ export function ExportChatMessagesItem({ checksums }: Props) {
       const payload: ExportMatchesChatMessagesPayload = {
         checksums,
         outputFolderPath,
+        steamIds,
       };
       const hasExportedAtLeastOneMatch = await client.send({
         name: RendererClientMessageName.ExportMatchesChatMessages,
@@ -65,6 +123,22 @@ export function ExportChatMessagesItem({ checksums }: Props) {
         content: <Trans>An error occurred</Trans>,
         type: 'error',
       });
+    }
+  };
+
+  const onClick = () => {
+    if (players && players.length > 0) {
+      showDialog(
+        <SelectPlayersDialog
+          players={players}
+          onConfirm={(steamIds) => {
+            hideDialog();
+            void exportChatMessagesForSteamIds(steamIds);
+          }}
+        />,
+      );
+    } else {
+      void exportChatMessagesForSteamIds([]);
     }
   };
 

--- a/src/ui/components/context-menu/items/export-chat-messages-item.tsx
+++ b/src/ui/components/context-menu/items/export-chat-messages-item.tsx
@@ -8,7 +8,6 @@ import type { ExportMatchesChatMessagesPayload } from 'csdm/server/handlers/rend
 import { useExportMatchChatMessages } from 'csdm/ui/hooks/use-export-match-chat-messages';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from 'csdm/ui/dialogs/dialog';
 import { useDialog } from 'csdm/ui/components/dialogs/use-dialog';
-import { Button } from 'csdm/ui/components/buttons/button';
 import { ConfirmButton } from 'csdm/ui/components/buttons/confirm-button';
 import { CancelButton } from 'csdm/ui/components/buttons/cancel-button';
 import { PlayersSelect } from '../../inputs/select/players-select';
@@ -21,11 +20,11 @@ type SelectPlayersDialogProps = {
 
 function SelectPlayersDialog({ players, onConfirm }: SelectPlayersDialogProps) {
   const { hideDialog } = useDialog();
-  const [steamIds, setSteamIds] = useState<string[]>([]);
+  const [steamIds, setSteamIds] = useState<string[]>(() => players.map((player) => player.steamId));
 
   return (
     <Dialog>
-      <div className="w-[768px]">
+      <div className="w-[512px]">
         <DialogHeader>
           <DialogTitle>
             <Trans>Chat messages export</Trans>
@@ -37,18 +36,11 @@ function SelectPlayersDialog({ players, onConfirm }: SelectPlayersDialogProps) {
               <Trans>Select the players whose chat messages you want to export.</Trans>
             </p>
             <div className="max-h-[220px] overflow-auto">
-              <PlayersSelect players={players} selectedSteamIds={steamIds} onChange={setSteamIds} filter={null} />
+              <PlayersSelect players={players} selectedSteamIds={steamIds} onChange={setSteamIds} />
             </div>
           </div>
         </DialogContent>
         <DialogFooter>
-          <Button
-            onClick={() => {
-              onConfirm([]);
-            }}
-          >
-            <Trans context="Button">Export all players</Trans>
-          </Button>
           <ConfirmButton
             onClick={() => {
               onConfirm(steamIds);

--- a/src/ui/components/context-menu/items/export-matches-item.tsx
+++ b/src/ui/components/context-menu/items/export-matches-item.tsx
@@ -34,6 +34,8 @@ export function ExportMatchesItem({ matches }: Props) {
       }
     }
   }
+  // Sort players alphabetically so they are easier to find in the voice/chat export dialogs.
+  players.sort((playerA, playerB) => playerA.name.localeCompare(playerB.name));
 
   const onExportToXlsxClick = () => {
     showDialog(<ExportMatchesAsXlsxDialog matches={matches} />);
@@ -44,7 +46,7 @@ export function ExportMatchesItem({ matches }: Props) {
       <ExportToXlsxItem onClick={onExportToXlsxClick} />
       <ExportMatchesToJsonItem checksums={checksums} />
       <ExportPlayersVoiceItem demoPaths={filepaths} players={players} />
-      <ExportChatMessagesItem checksums={checksums} />
+      <ExportChatMessagesItem checksums={checksums} players={players} />
     </SubContextMenu>
   );
 }

--- a/src/ui/components/context-menu/items/export-players-voice-item.tsx
+++ b/src/ui/components/context-menu/items/export-players-voice-item.tsx
@@ -167,7 +167,7 @@ type SelectExportModeDialogProps = {
 function SelectExportModeDialog({ onSelect, players }: SelectExportModeDialogProps) {
   const { hideDialog } = useDialog();
   const [mode, setMode] = useState<ExportVoiceMode>(ExportVoiceMode.SingleFull);
-  const [steamIds, setSteamIds] = useState<string[]>([]);
+  const [steamIds, setSteamIds] = useState<string[]>(() => players?.map((player) => player.steamId) ?? []);
   const options: SelectOption<ExportVoiceMode>[] = [
     {
       label: <Trans context="Voice mode export label">One file per player (no silence, only voice)</Trans>,
@@ -185,7 +185,7 @@ function SelectExportModeDialog({ onSelect, players }: SelectExportModeDialogPro
 
   return (
     <Dialog>
-      <div className="w-[768px]">
+      <div className="w-[512px]">
         <DialogHeader>
           <DialogTitle>
             <Trans>Players voice export</Trans>
@@ -201,7 +201,7 @@ function SelectExportModeDialog({ onSelect, players }: SelectExportModeDialogPro
             />
             {players && players.length > 0 && (
               <div className="mt-12 max-h-[220px] overflow-auto">
-                <PlayersSelect players={players} selectedSteamIds={steamIds} onChange={setSteamIds} filter={null} />
+                <PlayersSelect players={players} selectedSteamIds={steamIds} onChange={setSteamIds} />
               </div>
             )}
           </div>
@@ -211,6 +211,7 @@ function SelectExportModeDialog({ onSelect, players }: SelectExportModeDialogPro
             onClick={() => {
               onSelect(mode, steamIds);
             }}
+            isDisabled={players && players.length > 0 && steamIds.length === 0}
           />
           <CancelButton onClick={hideDialog} />
         </DialogFooter>

--- a/src/ui/hooks/use-export-match-chat-messages.tsx
+++ b/src/ui/hooks/use-export-match-chat-messages.tsx
@@ -12,7 +12,7 @@ export function useExportMatchChatMessages() {
   const showToast = useShowToast();
   const { t } = useLingui();
 
-  return async (checksum: string, messages?: ChatMessage[]) => {
+  return async (checksum: string, messages?: ChatMessage[], steamIds?: string[]) => {
     const options: SaveDialogOptions = {
       defaultPath: `messages-${checksum}.txt`,
       title: t({
@@ -31,6 +31,7 @@ export function useExportMatchChatMessages() {
         checksum,
         filePath,
         messages,
+        steamIds,
       };
       const hasMessages = await client.send({
         name: RendererClientMessageName.ExportMatchChatMessages,

--- a/src/ui/match/chat-messages/chat-messages.tsx
+++ b/src/ui/match/chat-messages/chat-messages.tsx
@@ -46,20 +46,16 @@ export function ChatMessages() {
     { value: match.teamB.name, label: match.teamB.name },
   ];
 
-  // Build the player list from the chat senders so everyone who actually spoke is selectable,
-  // including players who are no longer part of the match's final players list.
-  const senderNameBySteamId = new Map<string, string>();
-  for (const { senderSteamId, senderName } of match.chatMessages) {
-    // Skip empty SteamIDs since an empty string can't be used as a Select option value.
-    if (senderSteamId !== '' && !senderNameBySteamId.has(senderSteamId)) {
-      senderNameBySteamId.set(senderSteamId, senderName);
-    }
-  }
+  const selectablePlayers =
+    teamName === internalAllTeamValue ? match.players : match.players.filter((player) => player.teamName === teamName);
   const playerOptions: SelectOption[] = [
     { value: internalAllPlayersValue, label: <Trans>All players</Trans> },
-    ...Array.from(senderNameBySteamId, ([steamId, name]) => ({ value: steamId, label: name })).sort((a, b) =>
-      String(a.label).localeCompare(String(b.label)),
-    ),
+    ...selectablePlayers
+      .map((player) => ({
+        value: player.steamId,
+        label: player.name,
+      }))
+      .sort((playerA, playerB) => playerA.label.localeCompare(playerB.label)),
   ];
 
   return (
@@ -73,6 +69,7 @@ export function ChatMessages() {
               value={teamName}
               onChange={(teamName) => {
                 setTeamName(teamName);
+                setPlayerSteamId(internalAllPlayersValue);
               }}
             />
             <Select

--- a/src/ui/match/chat-messages/chat-messages.tsx
+++ b/src/ui/match/chat-messages/chat-messages.tsx
@@ -11,7 +11,9 @@ import { Select, type SelectOption } from 'csdm/ui/components/inputs/select';
 export function ChatMessages() {
   const match = useCurrentMatch();
   const internalAllTeamValue = 'csdm-all-teams';
+  const internalAllPlayersValue = 'csdm-all-players';
   const [teamName, setTeamName] = useState(internalAllTeamValue);
+  const [playerSteamId, setPlayerSteamId] = useState(internalAllPlayersValue);
   const [fuzzySearchText, setFuzzySearchText] = useState('');
 
   const { chatMessages, checksum } = match;
@@ -34,10 +36,30 @@ export function ChatMessages() {
     );
   }
 
+  if (playerSteamId !== internalAllPlayersValue) {
+    visibleChatMessages = visibleChatMessages.filter((message) => message.senderSteamId === playerSteamId);
+  }
+
   const options: SelectOption[] = [
     { value: internalAllTeamValue, label: <Trans>All teams</Trans> },
     { value: match.teamA.name, label: match.teamA.name },
     { value: match.teamB.name, label: match.teamB.name },
+  ];
+
+  // Build the player list from the chat senders so everyone who actually spoke is selectable,
+  // including players who are no longer part of the match's final players list.
+  const senderNameBySteamId = new Map<string, string>();
+  for (const { senderSteamId, senderName } of match.chatMessages) {
+    // Skip empty SteamIDs since an empty string can't be used as a Select option value.
+    if (senderSteamId !== '' && !senderNameBySteamId.has(senderSteamId)) {
+      senderNameBySteamId.set(senderSteamId, senderName);
+    }
+  }
+  const playerOptions: SelectOption[] = [
+    { value: internalAllPlayersValue, label: <Trans>All players</Trans> },
+    ...Array.from(senderNameBySteamId, ([steamId, name]) => ({ value: steamId, label: name })).sort((a, b) =>
+      String(a.label).localeCompare(String(b.label)),
+    ),
   ];
 
   return (
@@ -51,6 +73,13 @@ export function ChatMessages() {
               value={teamName}
               onChange={(teamName) => {
                 setTeamName(teamName);
+              }}
+            />
+            <Select
+              options={playerOptions}
+              value={playerSteamId}
+              onChange={(playerSteamId) => {
+                setPlayerSteamId(playerSteamId);
               }}
             />
             <TextInputFilter value={fuzzySearchText} onChange={setFuzzySearchText} />

--- a/src/ui/translations/de/messages.po
+++ b/src/ui/translations/de/messages.po
@@ -660,6 +660,19 @@ msgid "Enter"
 msgstr "Eingabe"
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Chat messages export"
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Select the players whose chat messages you want to export."
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgctxt "Button"
+msgid "Export all players"
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"
@@ -3742,6 +3755,10 @@ msgstr "*TOT*"
 
 #: src/ui/match/chat-messages/chat-messages.tsx
 msgid "All teams"
+msgstr ""
+
+#: src/ui/match/chat-messages/chat-messages.tsx
+msgid "All players"
 msgstr ""
 
 #: src/ui/match/chat-messages/empty-chat-messages.tsx

--- a/src/ui/translations/de/messages.po
+++ b/src/ui/translations/de/messages.po
@@ -668,11 +668,6 @@ msgid "Select the players whose chat messages you want to export."
 msgstr ""
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
-msgctxt "Button"
-msgid "Export all players"
-msgstr ""
-
-#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"

--- a/src/ui/translations/en/messages.po
+++ b/src/ui/translations/en/messages.po
@@ -663,11 +663,6 @@ msgid "Select the players whose chat messages you want to export."
 msgstr "Select the players whose chat messages you want to export."
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
-msgctxt "Button"
-msgid "Export all players"
-msgstr "Export all players"
-
-#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"

--- a/src/ui/translations/en/messages.po
+++ b/src/ui/translations/en/messages.po
@@ -655,6 +655,19 @@ msgid "Enter"
 msgstr "Enter"
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Chat messages export"
+msgstr "Chat messages export"
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Select the players whose chat messages you want to export."
+msgstr "Select the players whose chat messages you want to export."
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgctxt "Button"
+msgid "Export all players"
+msgstr "Export all players"
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"
@@ -3738,6 +3751,10 @@ msgstr "*DEAD*"
 #: src/ui/match/chat-messages/chat-messages.tsx
 msgid "All teams"
 msgstr "All teams"
+
+#: src/ui/match/chat-messages/chat-messages.tsx
+msgid "All players"
+msgstr "All players"
 
 #: src/ui/match/chat-messages/empty-chat-messages.tsx
 msgid "Chat messages are available only if the <0>.info</0> file of the demo is next to its <1>.dem</1> file during analysis."

--- a/src/ui/translations/es/messages.po
+++ b/src/ui/translations/es/messages.po
@@ -668,11 +668,6 @@ msgid "Select the players whose chat messages you want to export."
 msgstr ""
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
-msgctxt "Button"
-msgid "Export all players"
-msgstr ""
-
-#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"

--- a/src/ui/translations/es/messages.po
+++ b/src/ui/translations/es/messages.po
@@ -660,6 +660,19 @@ msgid "Enter"
 msgstr ""
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Chat messages export"
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Select the players whose chat messages you want to export."
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgctxt "Button"
+msgid "Export all players"
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"
@@ -3742,6 +3755,10 @@ msgstr ""
 
 #: src/ui/match/chat-messages/chat-messages.tsx
 msgid "All teams"
+msgstr ""
+
+#: src/ui/match/chat-messages/chat-messages.tsx
+msgid "All players"
 msgstr ""
 
 #: src/ui/match/chat-messages/empty-chat-messages.tsx

--- a/src/ui/translations/fr/messages.po
+++ b/src/ui/translations/fr/messages.po
@@ -660,6 +660,19 @@ msgid "Enter"
 msgstr "Entrer"
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Chat messages export"
+msgstr "Export des messages de chat"
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Select the players whose chat messages you want to export."
+msgstr "Sélectionnez les joueurs dont vous voulez exporter les messages."
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgctxt "Button"
+msgid "Export all players"
+msgstr "Exporter tous les joueurs"
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"
@@ -3743,6 +3756,10 @@ msgstr "*MORT*"
 #: src/ui/match/chat-messages/chat-messages.tsx
 msgid "All teams"
 msgstr "Toutes les équipes"
+
+#: src/ui/match/chat-messages/chat-messages.tsx
+msgid "All players"
+msgstr "Tous les joueurs"
 
 #: src/ui/match/chat-messages/empty-chat-messages.tsx
 msgid "Chat messages are available only if the <0>.info</0> file of the demo is next to its <1>.dem</1> file during analysis."

--- a/src/ui/translations/fr/messages.po
+++ b/src/ui/translations/fr/messages.po
@@ -668,11 +668,6 @@ msgid "Select the players whose chat messages you want to export."
 msgstr "Sélectionnez les joueurs dont vous voulez exporter les messages."
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
-msgctxt "Button"
-msgid "Export all players"
-msgstr "Exporter tous les joueurs"
-
-#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"

--- a/src/ui/translations/pt-BR/messages.po
+++ b/src/ui/translations/pt-BR/messages.po
@@ -668,11 +668,6 @@ msgid "Select the players whose chat messages you want to export."
 msgstr ""
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
-msgctxt "Button"
-msgid "Export all players"
-msgstr ""
-
-#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"

--- a/src/ui/translations/pt-BR/messages.po
+++ b/src/ui/translations/pt-BR/messages.po
@@ -660,6 +660,19 @@ msgid "Enter"
 msgstr ""
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Chat messages export"
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Select the players whose chat messages you want to export."
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgctxt "Button"
+msgid "Export all players"
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"
@@ -3742,6 +3755,10 @@ msgstr "*MORTO*"
 
 #: src/ui/match/chat-messages/chat-messages.tsx
 msgid "All teams"
+msgstr ""
+
+#: src/ui/match/chat-messages/chat-messages.tsx
+msgid "All players"
 msgstr ""
 
 #: src/ui/match/chat-messages/empty-chat-messages.tsx

--- a/src/ui/translations/ru/messages.po
+++ b/src/ui/translations/ru/messages.po
@@ -668,11 +668,6 @@ msgid "Select the players whose chat messages you want to export."
 msgstr ""
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
-msgctxt "Button"
-msgid "Export all players"
-msgstr ""
-
-#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"

--- a/src/ui/translations/ru/messages.po
+++ b/src/ui/translations/ru/messages.po
@@ -660,6 +660,19 @@ msgid "Enter"
 msgstr ""
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Chat messages export"
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Select the players whose chat messages you want to export."
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgctxt "Button"
+msgid "Export all players"
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"
@@ -3742,6 +3755,10 @@ msgstr ""
 
 #: src/ui/match/chat-messages/chat-messages.tsx
 msgid "All teams"
+msgstr ""
+
+#: src/ui/match/chat-messages/chat-messages.tsx
+msgid "All players"
 msgstr ""
 
 #: src/ui/match/chat-messages/empty-chat-messages.tsx

--- a/src/ui/translations/zh-CN/messages.po
+++ b/src/ui/translations/zh-CN/messages.po
@@ -660,6 +660,19 @@ msgid "Enter"
 msgstr "Enter"
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Chat messages export"
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Select the players whose chat messages you want to export."
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgctxt "Button"
+msgid "Export all players"
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"
@@ -3743,6 +3756,10 @@ msgstr "*死亡*"
 #: src/ui/match/chat-messages/chat-messages.tsx
 msgid "All teams"
 msgstr "所有队伍"
+
+#: src/ui/match/chat-messages/chat-messages.tsx
+msgid "All players"
+msgstr ""
 
 #: src/ui/match/chat-messages/empty-chat-messages.tsx
 msgid "Chat messages are available only if the <0>.info</0> file of the demo is next to its <1>.dem</1> file during analysis."

--- a/src/ui/translations/zh-CN/messages.po
+++ b/src/ui/translations/zh-CN/messages.po
@@ -668,11 +668,6 @@ msgid "Select the players whose chat messages you want to export."
 msgstr ""
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
-msgctxt "Button"
-msgid "Export all players"
-msgstr ""
-
-#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"

--- a/src/ui/translations/zh-TW/messages.po
+++ b/src/ui/translations/zh-TW/messages.po
@@ -668,11 +668,6 @@ msgid "Select the players whose chat messages you want to export."
 msgstr ""
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
-msgctxt "Button"
-msgid "Export all players"
-msgstr ""
-
-#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"

--- a/src/ui/translations/zh-TW/messages.po
+++ b/src/ui/translations/zh-TW/messages.po
@@ -660,6 +660,19 @@ msgid "Enter"
 msgstr "Enter"
 
 #: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Chat messages export"
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgid "Select the players whose chat messages you want to export."
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
+msgctxt "Button"
+msgid "Export all players"
+msgstr ""
+
+#: src/ui/components/context-menu/items/export-chat-messages-item.tsx
 #: src/ui/components/dialogs/export-matches-to-json-dialog.tsx
 msgctxt "Button label"
 msgid "Select"
@@ -3743,6 +3756,10 @@ msgstr "*死亡*"
 #: src/ui/match/chat-messages/chat-messages.tsx
 msgid "All teams"
 msgstr "所有隊伍"
+
+#: src/ui/match/chat-messages/chat-messages.tsx
+msgid "All players"
+msgstr ""
 
 #: src/ui/match/chat-messages/empty-chat-messages.tsx
 msgid "Chat messages are available only if the <0>.info</0> file of the demo is next to its <1>.dem</1> file during analysis."


### PR DESCRIPTION
Discussed in #1421

Add a player filter to the match Chat tab and a player selection dialog to the right-click chat export, mirroring the existing voice export. The backend gains an optional steamIds filter, so existing behavior is unchanged when no player is selected. Players are sorted alphabetically in the export dialogs.

<img width="1762" height="886" alt="electron_1PO58rQQTP" src="https://github.com/user-attachments/assets/6e0f0047-c36c-4dda-a60d-3308773d0c3c" />

<img width="1762" height="886" alt="electron_JrOdBjlJK7" src="https://github.com/user-attachments/assets/8db09362-3371-4a3a-a0e5-473beb120132" />