### PR TITLE
feat: update translations - zh-CN

### DIFF
--- a/src/ui/translations/zh-CN/messages.po
+++ b/src/ui/translations/zh-CN/messages.po
@@ -2801,7 +2801,7 @@ msgstr "Esportal"
 #: src/ui/demos/use-demo-sources.ts
 msgctxt "Demo source name"
 msgid "Esportligaen"
-msgstr ""
+msgstr "Esportligaen"
 
 #: src/ui/demos/use-demo-sources.ts
 msgctxt "Demo source name"
@@ -7838,7 +7838,7 @@ msgstr "在回合冻结时间结束之前的倒计时。"
 
 #: src/ui/settings/playback/watch-round-wait-round-end.tsx
 msgid "Wait for the round to end before skipping to the next round when watching player's rounds."
-msgstr ""
+msgstr "在观看玩家的回合时，请等待当前回合结束，再跳转到下一回合。"
 
 #: src/ui/settings/playback/watch-round-wait-round-end.tsx
 msgctxt "Settings title"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add two missing zh-CN translations: "Esportligaen" demo source name and the playback setting to wait for the round to end before skipping when watching a player's rounds. Removes blank labels in the demo source list and playback settings for Chinese users.

<sup>Written for commit 8de9623f42cfd4e3827c77ce0cc6a5f5574d4c30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akiver/cs-demo-manager/pull/1424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

