### PR TITLE
feat: unzip demos from archives

### DIFF
--- a/src/common/types/archive-format.ts
+++ b/src/common/types/archive-format.ts
@@ -1,0 +1,11 @@
+// Supported archive formats from which demos can be automatically extracted.
+// Values match the archive file extension (without the leading dot).
+export const ArchiveFormat = {
+  Zip: 'zip',
+  Gz: 'gz',
+  Bz2: 'bz2',
+} as const;
+
+export type ArchiveFormat = (typeof ArchiveFormat)[keyof typeof ArchiveFormat];
+
+export const supportedArchiveFormats: ArchiveFormat[] = [ArchiveFormat.Zip, ArchiveFormat.Gz, ArchiveFormat.Bz2];

--- a/src/common/types/load-demos-progress.ts
+++ b/src/common/types/load-demos-progress.ts
@@ -1,0 +1,15 @@
+// Steps reported while loading the demos table.
+// Archives are extracted first so their demos can be discovered, then the demos are loaded.
+export const LoadDemosStep = {
+  ScanningArchives: 'scanning-archives',
+  ExtractingArchives: 'extracting-archives',
+  LoadingDemos: 'loading-demos',
+} as const;
+
+export type LoadDemosStep = (typeof LoadDemosStep)[keyof typeof LoadDemosStep];
+
+export type LoadDemosProgress = {
+  step: LoadDemosStep;
+  current: number;
+  total: number;
+};

--- a/src/node/database/demos/fetch-demos-table.ts
+++ b/src/node/database/demos/fetch-demos-table.ts
@@ -7,6 +7,7 @@ import { fetchChecksumTags } from 'csdm/node/database/tags/fetch-checksum-tags';
 import { fetchComments } from 'csdm/node/database/comments/fetch-comments';
 import { getErrorCodeFromError } from 'csdm/server/get-error-code-from-error';
 import type { DemosTableFilter } from 'csdm/node/database/demos/demos-table-filter';
+import { LoadDemosStep, type LoadDemosProgress } from 'csdm/common/types/load-demos-progress';
 
 function applyFilters(filter: DemosTableFilter, demos: Demo[]) {
   const startDate = filter.startDate !== undefined ? new Date(filter.startDate) : undefined;
@@ -48,23 +49,38 @@ function applyFilters(filter: DemosTableFilter, demos: Demo[]) {
 }
 
 type Options = {
-  onProgress: (demoLoadedCount: number, demoToLoadCount: number) => void;
+  onProgress: (progress: LoadDemosProgress) => void;
 };
 
 export async function fetchDemosTable(filter: DemosTableFilter, { onProgress }: Options) {
   try {
-    const filePaths = await getDemosFilePathsToLoad();
+    const filePaths = await getDemosFilePathsToLoad({
+      onScanArchivesProgress: (scannedArchiveNumber, archiveCount) => {
+        onProgress({
+          step: LoadDemosStep.ScanningArchives,
+          current: scannedArchiveNumber,
+          total: archiveCount,
+        });
+      },
+      onExtractDemosProgress: (extractingDemoNumber, demoToExtractCount) => {
+        onProgress({
+          step: LoadDemosStep.ExtractingArchives,
+          current: extractingDemoNumber,
+          total: demoToExtractCount,
+        });
+      },
+    });
     const demosInDatabase = await fetchDemosByFilePaths(filePaths);
     const tags = await fetchChecksumTags();
     const comments = await fetchComments();
 
-    onProgress(0, filePaths.length);
+    onProgress({ step: LoadDemosStep.LoadingDemos, current: 0, total: filePaths.length });
 
     const demosToInsert: Demo[] = [];
     const demos: Demo[] = [];
     for (let i = 0; i < filePaths.length; i++) {
       const filePath = filePaths[i];
-      onProgress(i + 1, filePaths.length);
+      onProgress({ step: LoadDemosStep.LoadingDemos, current: i + 1, total: filePaths.length });
 
       try {
         const demoInDatabase = demosInDatabase.find((demo) => demo.filePath === filePath);

--- a/src/node/demo/demo-archive-extraction.ts
+++ b/src/node/demo/demo-archive-extraction.ts
@@ -1,0 +1,139 @@
+import path from 'node:path';
+import zlib from 'node:zlib';
+import { pipeline } from 'node:stream/promises';
+import { createReadStream, createWriteStream } from 'node:fs';
+import fs from 'fs-extra';
+import StreamZip from 'node-stream-zip';
+import bz2 from 'unbzip2-stream';
+import type { ArchiveFormat } from 'csdm/common/types/archive-format';
+
+export type DemoArchiveEntry = {
+  // Name (path) of the .dem entry inside the archive. For single-stream archives (.gz/.bz2) it's the demo file name.
+  entryName: string;
+  // Path where the demo is extracted on the filesystem, flat next to the archive.
+  destinationPath: string;
+  // Name (path) of the sibling .dem.info entry inside the archive, if any (Valve demos only).
+  infoFileName?: string;
+};
+
+export function buildArchiveSearchPatterns(formats: ArchiveFormat[], includeSubFolders: boolean): string[] {
+  return formats.map((format) => {
+    return includeSubFolders ? `**/*.${format}` : `*.${format}`;
+  });
+}
+
+// Lists the demos held by the archive that are not yet extracted next to it.
+// queuedDestinationPaths is used to avoid queuing the same destination path twice (e.g. two demos in different
+// sub-folders of a .zip that flatten to the same destination path).
+export async function getDemosToExtractFromArchive(
+  archivePath: string,
+  queuedDestinationPaths: Set<string> = new Set(),
+): Promise<DemoArchiveEntry[]> {
+  const extension = path.extname(archivePath).toLowerCase();
+
+  // .zip may hold several demos. Extract them flat next to the archive so demos in sub-folders are also discovered.
+  if (extension === '.zip') {
+    const demosToExtract: DemoArchiveEntry[] = [];
+    const zip = new StreamZip.async({ file: archivePath });
+    try {
+      const entries = await zip.entries();
+      const destinationFolderPath = path.dirname(archivePath);
+
+      for (const entry of Object.values(entries)) {
+        if (entry.isDirectory || !entry.name.toLowerCase().endsWith('.dem')) {
+          continue;
+        }
+
+        const destinationPath = path.join(destinationFolderPath, path.basename(entry.name));
+        // Different entries (e.g. same file name in different sub-folders) may flatten to the same destination path.
+        // Skip the duplicates instead of letting one silently overwrite another during extraction.
+        if (queuedDestinationPaths.has(destinationPath)) {
+          continue;
+        }
+
+        const alreadyExtracted = await fs.pathExists(destinationPath);
+        if (alreadyExtracted) {
+          continue;
+        }
+
+        queuedDestinationPaths.add(destinationPath);
+
+        const demoToExtract: DemoArchiveEntry = { entryName: entry.name, destinationPath };
+
+        // Valve demos may ship with a sibling .dem.info file holding match metadata, extract it too.
+        const infoFileName = `${entry.name}.info`;
+        if (entries[infoFileName]) {
+          demoToExtract.infoFileName = infoFileName;
+        }
+
+        demosToExtract.push(demoToExtract);
+      }
+    } finally {
+      await zip.close();
+    }
+
+    return demosToExtract;
+  }
+
+  // .gz/.bz2 hold a single compressed demo; its extracted name is the archive name minus the compression extension
+  // (e.g. match.dem.gz -> match.dem).
+  const destinationPath = archivePath.slice(0, -extension.length);
+  const isDemFile = destinationPath.toLowerCase().endsWith('.dem');
+  const isQueued = queuedDestinationPaths.has(destinationPath);
+  if (!isDemFile || isQueued || (await fs.pathExists(destinationPath))) {
+    return [];
+  }
+
+  queuedDestinationPaths.add(destinationPath);
+
+  return [{ entryName: path.basename(destinationPath), destinationPath }];
+}
+
+export async function extractDemosFromArchive(
+  archivePath: string,
+  demosToExtract: DemoArchiveEntry[],
+  onExtractingDemo?: () => void,
+): Promise<void> {
+  if (demosToExtract.length === 0) {
+    return;
+  }
+
+  const extension = path.extname(archivePath).toLowerCase();
+
+  if (extension === '.zip') {
+    const zip = new StreamZip.async({ file: archivePath });
+    try {
+      for (const { entryName, destinationPath, infoFileName } of demosToExtract) {
+        onExtractingDemo?.();
+        const tempDestinationPath = `${destinationPath}.tmp`;
+        const infoFileDestinationPath = `${destinationPath}.info`;
+        try {
+          await zip.extract(entryName, tempDestinationPath);
+          if (infoFileName) {
+            await zip.extract(infoFileName, infoFileDestinationPath);
+          }
+          await fs.rename(tempDestinationPath, destinationPath);
+        } catch (error) {
+          await Promise.all([fs.remove(tempDestinationPath), fs.remove(infoFileDestinationPath)]);
+          throw error;
+        }
+      }
+    } finally {
+      await zip.close();
+    }
+
+    return;
+  }
+
+  const [{ destinationPath }] = demosToExtract;
+  onExtractingDemo?.();
+  const decompressStream = extension === '.bz2' ? bz2() : zlib.createGunzip();
+  const tempDestinationPath = `${destinationPath}.tmp`;
+  try {
+    await pipeline(createReadStream(archivePath), decompressStream, createWriteStream(tempDestinationPath));
+    await fs.rename(tempDestinationPath, destinationPath);
+  } catch (error) {
+    await fs.remove(tempDestinationPath);
+    throw error;
+  }
+}

--- a/src/node/demo/find-demos-in-folders.ts
+++ b/src/node/demo/find-demos-in-folders.ts
@@ -1,8 +1,114 @@
 import { glob } from 'csdm/node/filesystem/glob';
 import type { Folder } from '../settings/settings';
 import { uniqueArray } from 'csdm/common/array/unique-array';
+import { getSettings } from 'csdm/node/settings/get-settings';
+import type { ArchiveFormat } from 'csdm/common/types/archive-format';
+import {
+  extractDemosFromArchive,
+  buildArchiveSearchPatterns,
+  getDemosToExtractFromArchive,
+  type DemoArchiveEntry,
+} from './demo-archive-extraction';
 
-export async function findDemosInFolders(folders: Folder[]) {
+type ExtractDemosProgress = (extractingDemoNumber: number, demoToExtractCount: number) => void;
+type ScanArchivesProgress = (scannedArchiveNumber: number, archiveCount: number) => void;
+
+export type FindDemosProgressCallbacks = {
+  onScanArchivesProgress?: ScanArchivesProgress;
+  onExtractDemosProgress?: ExtractDemosProgress;
+};
+
+async function findArchivesInFolders(folders: Folder[], formats: ArchiveFormat[]): Promise<string[]> {
+  const archivePaths: string[] = [];
+  for (const folder of folders) {
+    const patterns = buildArchiveSearchPatterns(formats, folder.includeSubFolders);
+    const paths = await glob(patterns, {
+      cwd: folder.path,
+      absolute: true,
+    });
+    archivePaths.push(...paths);
+  }
+
+  return uniqueArray(archivePaths);
+}
+
+type ExtractDemosFromArchivesArgs = FindDemosProgressCallbacks & {
+  folders: Folder[];
+  formats: ArchiveFormat[];
+};
+
+async function extractDemosFromArchives({
+  folders,
+  formats,
+  onScanArchivesProgress,
+  onExtractDemosProgress,
+}: ExtractDemosFromArchivesArgs) {
+  if (formats.length === 0) {
+    return;
+  }
+
+  const archivePaths = await findArchivesInFolders(folders, formats);
+  if (archivePaths.length === 0) {
+    return;
+  }
+
+  // Resolve the demos that still need to be extracted upfront so the progress reflects the actual
+  // number of demos to extract and not the number of archives (most of which may already be extracted).
+  const archives: { archivePath: string; demosToExtract: DemoArchiveEntry[] }[] = [];
+  let demoToExtractCount = 0;
+  // Shared across all archives so two archives that resolve to the same destination path (e.g. same demo file name)
+  // aren't both queued for extraction, which would let the second extraction silently overwrite the first.
+  const queuedDestinationPaths = new Set<string>();
+  let scannedArchiveNumber = 0;
+  for (const archivePath of archivePaths) {
+    try {
+      const demosToExtract = await getDemosToExtractFromArchive(archivePath, queuedDestinationPaths);
+      if (demosToExtract.length > 0) {
+        archives.push({ archivePath, demosToExtract });
+        demoToExtractCount += demosToExtract.length;
+      }
+    } catch (error) {
+      logger.error(`Error while reading archive ${archivePath}`);
+      logger.error(error);
+    } finally {
+      scannedArchiveNumber += 1;
+      onScanArchivesProgress?.(scannedArchiveNumber, archivePaths.length);
+    }
+  }
+
+  if (demoToExtractCount === 0) {
+    return;
+  }
+
+  let extractedDemoCount = 0;
+  for (const { archivePath, demosToExtract } of archives) {
+    let extractedFromArchive = 0;
+    try {
+      await extractDemosFromArchive(archivePath, demosToExtract, () => {
+        extractedFromArchive += 1;
+        onExtractDemosProgress?.(extractedDemoCount + extractedFromArchive, demoToExtractCount);
+      });
+    } catch (error) {
+      logger.error(`Error while extracting demos from archive ${archivePath}`);
+      logger.error(error);
+    } finally {
+      // Count the whole archive whether it fully succeeded or failed partway, so progress reaches 100%.
+      extractedDemoCount += demosToExtract.length;
+      onExtractDemosProgress?.(extractedDemoCount, demoToExtractCount);
+    }
+  }
+}
+
+export async function findDemosInFolders(folders: Folder[], progressCallbacks: FindDemosProgressCallbacks = {}) {
+  // Extract demos from compressed archives found in the folders, if any. This is done before searching for demos so
+  // that demos in archives are also discovered. Only the archive formats enabled in the settings are extracted.
+  const settings = await getSettings();
+  await extractDemosFromArchives({
+    folders,
+    formats: settings.autoExtractDemosFromArchives,
+    ...progressCallbacks,
+  });
+
   const demoPaths: string[] = [];
   for (const folder of folders) {
     const pattern = folder.includeSubFolders ? '**/*.dem' : '*.dem';

--- a/src/node/demo/get-demos-file-paths-to-load.ts
+++ b/src/node/demo/get-demos-file-paths-to-load.ts
@@ -1,6 +1,6 @@
 import type { Folder } from 'csdm/node/settings/settings';
 import { getSettings } from 'csdm/node/settings/get-settings';
-import { findDemosInFolders } from './find-demos-in-folders';
+import { findDemosInFolders, type FindDemosProgressCallbacks } from './find-demos-in-folders';
 
 async function getFoldersToInclude(): Promise<Folder[]> {
   const settings = await getSettings();
@@ -20,9 +20,9 @@ async function getFoldersToInclude(): Promise<Folder[]> {
   return foldersToInclude;
 }
 
-export async function getDemosFilePathsToLoad() {
+export async function getDemosFilePathsToLoad(progressCallbacks: FindDemosProgressCallbacks = {}) {
   const foldersToInclude = await getFoldersToInclude();
-  const filePaths = await findDemosInFolders(foldersToInclude);
+  const filePaths = await findDemosInFolders(foldersToInclude, progressCallbacks);
 
   return filePaths;
 }

--- a/src/node/settings/default-settings.ts
+++ b/src/node/settings/default-settings.ts
@@ -20,6 +20,7 @@ export const defaultSettings: Settings = {
     database: 'csdm',
   },
   folders: [],
+  autoExtractDemosFromArchives: [],
   demos: {
     showAllFolders: false,
     currentFolderPath: '',

--- a/src/node/settings/get-all-migrations.ts
+++ b/src/node/settings/get-all-migrations.ts
@@ -17,6 +17,7 @@ export async function getAllMigrations(): Promise<Migration[]> {
     import('./migrations/v10'),
     import('./migrations/v11'),
     import('./migrations/v12'),
+    import('./migrations/v13'),
   ]);
   const migrations: Migration[] = modules.map((module) => module.default);
 

--- a/src/node/settings/migrations/v13.ts
+++ b/src/node/settings/migrations/v13.ts
@@ -1,0 +1,13 @@
+import type { Settings } from '../settings';
+import type { Migration } from '../migration';
+
+const v13: Migration = {
+  schemaVersion: 13,
+  run: (settings: Settings) => {
+    settings.autoExtractDemosFromArchives = [];
+
+    return Promise.resolve(settings);
+  },
+};
+
+export default v13;

--- a/src/node/settings/schema-version.ts
+++ b/src/node/settings/schema-version.ts
@@ -2,4 +2,4 @@
 // It's used to migrate settings schema at app startup.
 // If you need to alter the settings schema or change current settings values, this variable has to be incremented
 // and the corresponding migration must be added to the getAllMigrations function!
-export const CURRENT_SCHEMA_VERSION = 12;
+export const CURRENT_SCHEMA_VERSION = 13;

--- a/src/node/settings/settings.ts
+++ b/src/node/settings/settings.ts
@@ -11,6 +11,7 @@ import type { TeamsTableFilter } from 'csdm/node/database/teams/teams-table-filt
 import type { RecordingSystem } from 'csdm/common/types/recording-system';
 import type { RecordingOutput } from 'csdm/common/types/recording-output';
 import type { DisplayMode } from 'csdm/common/types/display-mode';
+import type { ArchiveFormat } from 'csdm/common/types/archive-format';
 
 export type Folder = {
   path: string;
@@ -176,6 +177,7 @@ export type Settings = {
   autoDownloadUpdates: boolean;
   database: DatabaseSettings;
   folders: Folder[];
+  autoExtractDemosFromArchives: ArchiveFormat[];
   demos: DemosSettings;
   steamApiKey: string;
   faceitApiKey: string;

--- a/src/server/handlers/renderer-process/demo/fetch-demos-table-handler.ts
+++ b/src/server/handlers/renderer-process/demo/fetch-demos-table-handler.ts
@@ -7,13 +7,10 @@ import { handleError } from '../../handle-error';
 export async function fetchDemosTableHandler(filter: DemosTableFilter) {
   try {
     const demos = fetchDemosTable(filter, {
-      onProgress: (demoLoadedCount, demoToLoadCount) => {
+      onProgress: (progress) => {
         server.sendMessageToRendererProcess({
           name: RendererServerMessageName.FetchDemosProgress,
-          payload: {
-            demoLoadedCount,
-            demoToLoadCount,
-          },
+          payload: progress,
         });
       },
     });

--- a/src/server/renderer-server-message-name.ts
+++ b/src/server/renderer-server-message-name.ts
@@ -3,6 +3,7 @@ import type { Analysis } from 'csdm/common/types/analysis';
 import type { MatchTable } from 'csdm/common/types/match-table';
 import type { Download, DownloadDemoProgressPayload, DownloadDemoSuccess } from 'csdm/common/download/download-types';
 import type { Demo } from '../common/types/demo';
+import type { LoadDemosProgress } from '../common/types/load-demos-progress';
 import type { ErrorCode } from '../common/error-code';
 import type { ValveMatch } from '../common/types/valve-match';
 import type { SharedServerMessagePayload, SharedServerMessageName } from './shared-server-message-name';
@@ -63,10 +64,7 @@ export type RendererServerMessageName =
 export interface RendererServerMessagePayload extends SharedServerMessagePayload {
   [RendererServerMessageName.SettingsUpdated]: Settings;
   [RendererServerMessageName.OptimizeDatabaseSuccess]: void;
-  [RendererServerMessageName.FetchDemosProgress]: {
-    demoLoadedCount: number;
-    demoToLoadCount: number;
-  };
+  [RendererServerMessageName.FetchDemosProgress]: LoadDemosProgress;
   [RendererServerMessageName.NavigateToDemo]: string;
   [RendererServerMessageName.NavigateToMatch]: string;
   [RendererServerMessageName.DemosAddedToAnalyses]: Analysis[];

--- a/src/ui/demos/demos-actions.ts
+++ b/src/ui/demos/demos-actions.ts
@@ -1,12 +1,10 @@
 import { createAction } from '@reduxjs/toolkit';
 import type { DemoSource, DemoType } from 'csdm/common/types/counter-strike';
 import type { Demo } from 'csdm/common/types/demo';
+import type { LoadDemosProgress } from 'csdm/common/types/load-demos-progress';
 
 export const fetchDemosStart = createAction('demos/fetchStart');
-export const fetchDemosProgress = createAction<{
-  demoLoadedCount: number;
-  demoToLoadCount: number;
-}>('demos/fetchProgress');
+export const fetchDemosProgress = createAction<LoadDemosProgress>('demos/fetchProgress');
 export const fetchDemosError = createAction('demos/fetchError');
 export const fetchDemosSuccess = createAction<Demo[]>('demos/fetchSuccess');
 export const deleteDemosSuccess = createAction<string[]>('demos/deleteSuccess');

--- a/src/ui/demos/demos-reducer.ts
+++ b/src/ui/demos/demos-reducer.ts
@@ -1,6 +1,7 @@
 import { createReducer } from '@reduxjs/toolkit';
 import type { Demo } from 'csdm/common/types/demo';
 import { Status } from 'csdm/common/types/status';
+import { LoadDemosStep, type LoadDemosProgress } from 'csdm/common/types/load-demos-progress';
 import { folderRemoved, folderAdded, folderUpdated } from 'csdm/ui/settings/folders/folder-actions';
 import {
   deleteDemosSuccess,
@@ -26,8 +27,7 @@ export type DemosState = {
   readonly entities: Demo[];
   readonly selectedDemosPath: string[];
   readonly fuzzySearchText: string;
-  readonly loadedDemoCount: number;
-  readonly demoToLoadCount: number;
+  readonly progress: LoadDemosProgress;
 };
 
 const initialState: DemosState = {
@@ -35,8 +35,11 @@ const initialState: DemosState = {
   entities: [],
   selectedDemosPath: [],
   fuzzySearchText: '',
-  loadedDemoCount: 0,
-  demoToLoadCount: 0,
+  progress: {
+    step: LoadDemosStep.LoadingDemos,
+    current: 0,
+    total: 0,
+  },
 };
 
 export const demosReducer = createReducer(initialState, (builder) => {
@@ -44,8 +47,7 @@ export const demosReducer = createReducer(initialState, (builder) => {
     .addCase(fetchDemosStart, (state) => {
       state.status = Status.Loading;
       state.entities = [];
-      state.demoToLoadCount = 0;
-      state.loadedDemoCount = 0;
+      state.progress = initialState.progress;
     })
     .addCase(fetchDemosSuccess, (state, action) => {
       state.status = Status.Success;
@@ -55,8 +57,7 @@ export const demosReducer = createReducer(initialState, (builder) => {
       state.status = Status.Error;
     })
     .addCase(fetchDemosProgress, (state, action) => {
-      state.demoToLoadCount = action.payload.demoToLoadCount;
-      state.loadedDemoCount = action.payload.demoLoadedCount;
+      state.progress = action.payload;
     })
     .addCase(deleteDemosSuccess, (state, action) => {
       state.entities = state.entities.filter((demo) => {

--- a/src/ui/demos/table/demos-table.tsx
+++ b/src/ui/demos/table/demos-table.tsx
@@ -15,12 +15,12 @@ import { useDemosState } from '../use-demos-state';
 
 export function DemosTable() {
   const status = useDemosStatus();
-  const { loadedDemoCount, demoToLoadCount } = useDemosState();
+  const { progress } = useDemosState();
   const table = useDemosTable();
   const folders = useFolders();
 
   if (status === Status.Idle || status === Status.Loading || !table.isReady()) {
-    return <LoadingDemosMessage loadedDemoCount={loadedDemoCount} demoToLoadCount={demoToLoadCount} />;
+    return <LoadingDemosMessage progress={progress} />;
   }
 
   if (folders.length === 0) {

--- a/src/ui/demos/table/loading-demos-message.tsx
+++ b/src/ui/demos/table/loading-demos-message.tsx
@@ -1,14 +1,40 @@
 import React from 'react';
 import { Trans } from '@lingui/react/macro';
 import { Message } from 'csdm/ui/components/message';
+import { LoadDemosStep, type LoadDemosProgress } from 'csdm/common/types/load-demos-progress';
 
 type Props = {
-  loadedDemoCount: number;
-  demoToLoadCount: number;
+  progress: LoadDemosProgress;
 };
 
-export function LoadingDemosMessage({ loadedDemoCount, demoToLoadCount }: Props) {
-  if (loadedDemoCount === 0 || demoToLoadCount === 0) {
+export function LoadingDemosMessage({ progress }: Props) {
+  const { step, current, total } = progress;
+
+  if (step === LoadDemosStep.ScanningArchives && total > 0) {
+    return (
+      <Message
+        message={
+          <Trans>
+            Scanning archive {current} of {total}…
+          </Trans>
+        }
+      />
+    );
+  }
+
+  if (step === LoadDemosStep.ExtractingArchives && total > 0) {
+    return (
+      <Message
+        message={
+          <Trans>
+            Extracting demo {current} of {total} from archives…
+          </Trans>
+        }
+      />
+    );
+  }
+
+  if (current === 0 || total === 0) {
     return <Message message={<Trans>Loading demos…</Trans>} />;
   }
 
@@ -16,7 +42,7 @@ export function LoadingDemosMessage({ loadedDemoCount, demoToLoadCount }: Props)
     <Message
       message={
         <Trans>
-          Loading {loadedDemoCount} of {demoToLoadCount} demos…
+          Loading {current} of {total} demos…
         </Trans>
       }
     />

--- a/src/ui/settings/folders/demo-archive-extraction-settings.tsx
+++ b/src/ui/settings/folders/demo-archive-extraction-settings.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Trans } from '@lingui/react/macro';
+import { Switch } from 'csdm/ui/components/inputs/switch';
+import { ExclamationTriangleIcon } from 'csdm/ui/icons/exclamation-triangle-icon';
+import { uniqueArray } from 'csdm/common/array/unique-array';
+import { type ArchiveFormat, supportedArchiveFormats } from 'csdm/common/types/archive-format';
+import { useSettings } from 'csdm/ui/settings/use-settings';
+import { useUpdateSettings } from 'csdm/ui/settings/use-update-settings';
+
+function ArchiveFormatSwitch({ format }: { format: ArchiveFormat }) {
+  const { autoExtractDemosFromArchives } = useSettings();
+  const updateSettings = useUpdateSettings();
+  const isChecked = autoExtractDemosFromArchives.includes(format);
+  const id = `archive-format-${format}`;
+
+  const onChange = async (checked: boolean) => {
+    const newFormats = checked
+      ? uniqueArray([...autoExtractDemosFromArchives, format])
+      : autoExtractDemosFromArchives.filter((enabledFormat) => enabledFormat !== format);
+    await updateSettings({ autoExtractDemosFromArchives: newFormats }, { preserveSourceArray: true });
+  };
+
+  return (
+    <div className="flex items-center gap-x-4">
+      <Switch id={id} isChecked={isChecked} onChange={onChange} />
+      <label htmlFor={id} className="cursor-pointer text-body-strong">{`.${format}`}</label>
+    </div>
+  );
+}
+
+export function DemoArchiveExtractionSettings() {
+  return (
+    <div className="flex flex-col gap-y-8 border-b border-b-gray-300 pb-16">
+      <div>
+        <p className="text-body-strong">
+          <Trans>Automatic demo extraction from archives</Trans>
+        </p>
+        <p className="mt-4 text-caption">
+          <Trans>
+            Automatically extract demos contained in archives found in your folders when scanning for demos. Extracted
+            demos are placed next to their archive.
+          </Trans>
+        </p>
+        <div className="mt-4 flex items-center gap-x-4">
+          <ExclamationTriangleIcon className="size-12 shrink-0 text-orange-700" />
+          <p className="text-caption">
+            <Trans>Enabling automatic extraction has an impact on demo loading speed!</Trans>
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-x-16">
+        {supportedArchiveFormats.map((format) => {
+          return <ArchiveFormatSwitch key={format} format={format} />;
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/settings/folders/folders-settings.tsx
+++ b/src/ui/settings/folders/folders-settings.tsx
@@ -1,13 +1,25 @@
 import React from 'react';
+import { Trans } from '@lingui/react/macro';
 import { SettingsView } from 'csdm/ui/settings/settings-view';
 import { FoldersList } from './folders-list';
 import { AddFolderButton } from './add-folder-button';
+import { DemoArchiveExtractionSettings } from './demo-archive-extraction-settings';
 
 export function FoldersSettings() {
   return (
     <SettingsView>
-      <AddFolderButton />
-      <FoldersList />
+      <div className="flex flex-col gap-y-12">
+        <DemoArchiveExtractionSettings />
+        <div>
+          <div className="flex items-center justify-between">
+            <h2 className="text-subtitle">
+              <Trans>Folders</Trans>
+            </h2>
+            <AddFolderButton />
+          </div>
+          <FoldersList />
+        </div>
+      </div>
     </SettingsView>
   );
 }

--- a/src/ui/settings/settings-entry.tsx
+++ b/src/ui/settings/settings-entry.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import React from 'react';
 
 type Props = {
-  description: string | ReactNode;
+  description?: string | ReactNode;
   title: string | ReactNode;
   interactiveComponent: ReactNode;
 };
@@ -12,7 +12,7 @@ export function SettingsEntry({ title, interactiveComponent, description }: Prop
     <div className="flex items-center justify-between border-b border-b-gray-300 py-8">
       <div className="pr-16">
         <p className="text-body-strong">{title}</p>
-        <div className="mt-4">{description}</div>
+        {description && <div className="mt-4">{description}</div>}
       </div>
       <div>{interactiveComponent}</div>
     </div>

--- a/src/ui/translations/de/messages.po
+++ b/src/ui/translations/de/messages.po
@@ -2713,12 +2713,20 @@ msgid "No folders found."
 msgstr "Keine Ordner gefunden."
 
 #: src/ui/demos/table/loading-demos-message.tsx
+msgid "Scanning archive {current} of {total}…"
+msgstr ""
+
+#: src/ui/demos/table/loading-demos-message.tsx
+msgid "Extracting demo {current} of {total} from archives…"
+msgstr ""
+
+#: src/ui/demos/table/loading-demos-message.tsx
 msgid "Loading demos…"
 msgstr "Demos werden geladen…"
 
 #: src/ui/demos/table/loading-demos-message.tsx
-msgid "Loading {loadedDemoCount} of {demoToLoadCount} demos…"
-msgstr "Lade {loadedDemoCount} von {demoToLoadCount} Demos…"
+msgid "Loading {current} of {total} demos…"
+msgstr ""
 
 #: src/ui/demos/table/no-demos.tsx
 msgid "No demos found with current filters."
@@ -7403,8 +7411,25 @@ msgctxt "Button"
 msgid "Add a folder"
 msgstr ""
 
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatic demo extraction from archives"
+msgstr ""
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatically extract demos contained in archives found in your folders when scanning for demos. Extracted demos are placed next to their archive."
+msgstr ""
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Enabling automatic extraction has an impact on demo loading speed!"
+msgstr ""
+
 #: src/ui/settings/folders/folder-row.tsx
 msgid "This folder contains characters that will prevent demo playback when starting CS:GO! (not CS2)"
+msgstr ""
+
+#: src/ui/settings/folders/folders-settings.tsx
+#: src/ui/settings/settings-tabs.tsx
+msgid "Folders"
 msgstr ""
 
 #: src/ui/settings/folders/include-sub-folders-switch.tsx
@@ -7822,10 +7847,6 @@ msgstr ""
 
 #: src/ui/settings/settings-tabs.tsx
 msgid "UI"
-msgstr ""
-
-#: src/ui/settings/settings-tabs.tsx
-msgid "Folders"
 msgstr ""
 
 #: src/ui/settings/settings-tabs.tsx

--- a/src/ui/translations/en/messages.po
+++ b/src/ui/translations/en/messages.po
@@ -2708,12 +2708,20 @@ msgid "No folders found."
 msgstr "No folders found."
 
 #: src/ui/demos/table/loading-demos-message.tsx
+msgid "Scanning archive {current} of {total}…"
+msgstr "Scanning archive {current} of {total}…"
+
+#: src/ui/demos/table/loading-demos-message.tsx
+msgid "Extracting demo {current} of {total} from archives…"
+msgstr "Extracting demo {current} of {total} from archives…"
+
+#: src/ui/demos/table/loading-demos-message.tsx
 msgid "Loading demos…"
 msgstr "Loading demos…"
 
 #: src/ui/demos/table/loading-demos-message.tsx
-msgid "Loading {loadedDemoCount} of {demoToLoadCount} demos…"
-msgstr "Loading {loadedDemoCount} of {demoToLoadCount} demos…"
+msgid "Loading {current} of {total} demos…"
+msgstr "Loading {current} of {total} demos…"
 
 #: src/ui/demos/table/no-demos.tsx
 msgid "No demos found with current filters."
@@ -7401,9 +7409,26 @@ msgctxt "Button"
 msgid "Add a folder"
 msgstr "Add a folder"
 
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatic demo extraction from archives"
+msgstr "Automatic demo extraction from archives"
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatically extract demos contained in archives found in your folders when scanning for demos. Extracted demos are placed next to their archive."
+msgstr "Automatically extract demos contained in archives found in your folders when scanning for demos. Extracted demos are placed next to their archive."
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Enabling automatic extraction has an impact on demo loading speed!"
+msgstr "Enabling automatic extraction has an impact on demo loading speed!"
+
 #: src/ui/settings/folders/folder-row.tsx
 msgid "This folder contains characters that will prevent demo playback when starting CS:GO! (not CS2)"
 msgstr "This folder contains characters that will prevent demo playback when starting CS:GO! (not CS2)"
+
+#: src/ui/settings/folders/folders-settings.tsx
+#: src/ui/settings/settings-tabs.tsx
+msgid "Folders"
+msgstr "Folders"
 
 #: src/ui/settings/folders/include-sub-folders-switch.tsx
 msgid "Include subfolders"
@@ -7821,10 +7846,6 @@ msgstr "Wait for round end"
 #: src/ui/settings/settings-tabs.tsx
 msgid "UI"
 msgstr "UI"
-
-#: src/ui/settings/settings-tabs.tsx
-msgid "Folders"
-msgstr "Folders"
 
 #: src/ui/settings/settings-tabs.tsx
 msgid "Maps"

--- a/src/ui/translations/es/messages.po
+++ b/src/ui/translations/es/messages.po
@@ -2713,11 +2713,19 @@ msgid "No folders found."
 msgstr ""
 
 #: src/ui/demos/table/loading-demos-message.tsx
+msgid "Scanning archive {current} of {total}…"
+msgstr ""
+
+#: src/ui/demos/table/loading-demos-message.tsx
+msgid "Extracting demo {current} of {total} from archives…"
+msgstr ""
+
+#: src/ui/demos/table/loading-demos-message.tsx
 msgid "Loading demos…"
 msgstr ""
 
 #: src/ui/demos/table/loading-demos-message.tsx
-msgid "Loading {loadedDemoCount} of {demoToLoadCount} demos…"
+msgid "Loading {current} of {total} demos…"
 msgstr ""
 
 #: src/ui/demos/table/no-demos.tsx
@@ -7403,8 +7411,25 @@ msgctxt "Button"
 msgid "Add a folder"
 msgstr ""
 
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatic demo extraction from archives"
+msgstr ""
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatically extract demos contained in archives found in your folders when scanning for demos. Extracted demos are placed next to their archive."
+msgstr ""
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Enabling automatic extraction has an impact on demo loading speed!"
+msgstr ""
+
 #: src/ui/settings/folders/folder-row.tsx
 msgid "This folder contains characters that will prevent demo playback when starting CS:GO! (not CS2)"
+msgstr ""
+
+#: src/ui/settings/folders/folders-settings.tsx
+#: src/ui/settings/settings-tabs.tsx
+msgid "Folders"
 msgstr ""
 
 #: src/ui/settings/folders/include-sub-folders-switch.tsx
@@ -7822,10 +7847,6 @@ msgstr ""
 
 #: src/ui/settings/settings-tabs.tsx
 msgid "UI"
-msgstr ""
-
-#: src/ui/settings/settings-tabs.tsx
-msgid "Folders"
 msgstr ""
 
 #: src/ui/settings/settings-tabs.tsx

--- a/src/ui/translations/fr/messages.po
+++ b/src/ui/translations/fr/messages.po
@@ -2713,12 +2713,20 @@ msgid "No folders found."
 msgstr "Aucun dossier trouvé."
 
 #: src/ui/demos/table/loading-demos-message.tsx
+msgid "Scanning archive {current} of {total}…"
+msgstr ""
+
+#: src/ui/demos/table/loading-demos-message.tsx
+msgid "Extracting demo {current} of {total} from archives…"
+msgstr ""
+
+#: src/ui/demos/table/loading-demos-message.tsx
 msgid "Loading demos…"
 msgstr "Chargement des démos…"
 
 #: src/ui/demos/table/loading-demos-message.tsx
-msgid "Loading {loadedDemoCount} of {demoToLoadCount} demos…"
-msgstr "Chargement de {loadedDemoCount} sur {demoToLoadCount} démos…"
+msgid "Loading {current} of {total} demos…"
+msgstr ""
 
 #: src/ui/demos/table/no-demos.tsx
 msgid "No demos found with current filters."
@@ -7403,9 +7411,26 @@ msgctxt "Button"
 msgid "Add a folder"
 msgstr "Ajouter un dossier"
 
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatic demo extraction from archives"
+msgstr ""
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatically extract demos contained in archives found in your folders when scanning for demos. Extracted demos are placed next to their archive."
+msgstr ""
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Enabling automatic extraction has an impact on demo loading speed!"
+msgstr ""
+
 #: src/ui/settings/folders/folder-row.tsx
 msgid "This folder contains characters that will prevent demo playback when starting CS:GO! (not CS2)"
 msgstr "Ce dossier contient des caractères qui empêcheront la lecture des démos au démarrage de CS:GO! (pas CS2)"
+
+#: src/ui/settings/folders/folders-settings.tsx
+#: src/ui/settings/settings-tabs.tsx
+msgid "Folders"
+msgstr "Dossiers"
 
 #: src/ui/settings/folders/include-sub-folders-switch.tsx
 msgid "Include subfolders"
@@ -7823,10 +7848,6 @@ msgstr ""
 #: src/ui/settings/settings-tabs.tsx
 msgid "UI"
 msgstr "UI"
-
-#: src/ui/settings/settings-tabs.tsx
-msgid "Folders"
-msgstr "Dossiers"
 
 #: src/ui/settings/settings-tabs.tsx
 msgid "Maps"

--- a/src/ui/translations/pt-BR/messages.po
+++ b/src/ui/translations/pt-BR/messages.po
@@ -2713,12 +2713,20 @@ msgid "No folders found."
 msgstr "Nenhuma pasta encontrada."
 
 #: src/ui/demos/table/loading-demos-message.tsx
+msgid "Scanning archive {current} of {total}…"
+msgstr ""
+
+#: src/ui/demos/table/loading-demos-message.tsx
+msgid "Extracting demo {current} of {total} from archives…"
+msgstr ""
+
+#: src/ui/demos/table/loading-demos-message.tsx
 msgid "Loading demos…"
 msgstr "Carregando demos…"
 
 #: src/ui/demos/table/loading-demos-message.tsx
-msgid "Loading {loadedDemoCount} of {demoToLoadCount} demos…"
-msgstr "Carregando {loadedDemoCount} de {demoToLoadCount} demos…"
+msgid "Loading {current} of {total} demos…"
+msgstr ""
 
 #: src/ui/demos/table/no-demos.tsx
 msgid "No demos found with current filters."
@@ -7403,9 +7411,26 @@ msgctxt "Button"
 msgid "Add a folder"
 msgstr ""
 
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatic demo extraction from archives"
+msgstr ""
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatically extract demos contained in archives found in your folders when scanning for demos. Extracted demos are placed next to their archive."
+msgstr ""
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Enabling automatic extraction has an impact on demo loading speed!"
+msgstr ""
+
 #: src/ui/settings/folders/folder-row.tsx
 msgid "This folder contains characters that will prevent demo playback when starting CS:GO! (not CS2)"
 msgstr ""
+
+#: src/ui/settings/folders/folders-settings.tsx
+#: src/ui/settings/settings-tabs.tsx
+msgid "Folders"
+msgstr "Pastas"
 
 #: src/ui/settings/folders/include-sub-folders-switch.tsx
 msgid "Include subfolders"
@@ -7823,10 +7848,6 @@ msgstr ""
 #: src/ui/settings/settings-tabs.tsx
 msgid "UI"
 msgstr "Interface do usuário"
-
-#: src/ui/settings/settings-tabs.tsx
-msgid "Folders"
-msgstr "Pastas"
 
 #: src/ui/settings/settings-tabs.tsx
 msgid "Maps"

--- a/src/ui/translations/ru/messages.po
+++ b/src/ui/translations/ru/messages.po
@@ -2713,11 +2713,19 @@ msgid "No folders found."
 msgstr ""
 
 #: src/ui/demos/table/loading-demos-message.tsx
+msgid "Scanning archive {current} of {total}…"
+msgstr ""
+
+#: src/ui/demos/table/loading-demos-message.tsx
+msgid "Extracting demo {current} of {total} from archives…"
+msgstr ""
+
+#: src/ui/demos/table/loading-demos-message.tsx
 msgid "Loading demos…"
 msgstr ""
 
 #: src/ui/demos/table/loading-demos-message.tsx
-msgid "Loading {loadedDemoCount} of {demoToLoadCount} demos…"
+msgid "Loading {current} of {total} demos…"
 msgstr ""
 
 #: src/ui/demos/table/no-demos.tsx
@@ -7403,8 +7411,25 @@ msgctxt "Button"
 msgid "Add a folder"
 msgstr ""
 
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatic demo extraction from archives"
+msgstr ""
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatically extract demos contained in archives found in your folders when scanning for demos. Extracted demos are placed next to their archive."
+msgstr ""
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Enabling automatic extraction has an impact on demo loading speed!"
+msgstr ""
+
 #: src/ui/settings/folders/folder-row.tsx
 msgid "This folder contains characters that will prevent demo playback when starting CS:GO! (not CS2)"
+msgstr ""
+
+#: src/ui/settings/folders/folders-settings.tsx
+#: src/ui/settings/settings-tabs.tsx
+msgid "Folders"
 msgstr ""
 
 #: src/ui/settings/folders/include-sub-folders-switch.tsx
@@ -7822,10 +7847,6 @@ msgstr ""
 
 #: src/ui/settings/settings-tabs.tsx
 msgid "UI"
-msgstr ""
-
-#: src/ui/settings/settings-tabs.tsx
-msgid "Folders"
 msgstr ""
 
 #: src/ui/settings/settings-tabs.tsx

--- a/src/ui/translations/zh-CN/messages.po
+++ b/src/ui/translations/zh-CN/messages.po
@@ -2713,12 +2713,20 @@ msgid "No folders found."
 msgstr "未找到文件夹。"
 
 #: src/ui/demos/table/loading-demos-message.tsx
+msgid "Scanning archive {current} of {total}…"
+msgstr ""
+
+#: src/ui/demos/table/loading-demos-message.tsx
+msgid "Extracting demo {current} of {total} from archives…"
+msgstr ""
+
+#: src/ui/demos/table/loading-demos-message.tsx
 msgid "Loading demos…"
 msgstr "加载 demo 中…"
 
 #: src/ui/demos/table/loading-demos-message.tsx
-msgid "Loading {loadedDemoCount} of {demoToLoadCount} demos…"
-msgstr "{demoToLoadCount} 个 demo 已加载 {loadedDemoCount} 个…"
+msgid "Loading {current} of {total} demos…"
+msgstr ""
 
 #: src/ui/demos/table/no-demos.tsx
 msgid "No demos found with current filters."
@@ -7403,9 +7411,26 @@ msgctxt "Button"
 msgid "Add a folder"
 msgstr "增加一个文件夹"
 
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatic demo extraction from archives"
+msgstr ""
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatically extract demos contained in archives found in your folders when scanning for demos. Extracted demos are placed next to their archive."
+msgstr ""
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Enabling automatic extraction has an impact on demo loading speed!"
+msgstr ""
+
 #: src/ui/settings/folders/folder-row.tsx
 msgid "This folder contains characters that will prevent demo playback when starting CS:GO! (not CS2)"
 msgstr "此文件夹包含在启动CS:GO时阻止demo播放的字符！(不是CS2)"
+
+#: src/ui/settings/folders/folders-settings.tsx
+#: src/ui/settings/settings-tabs.tsx
+msgid "Folders"
+msgstr "文件夹"
 
 #: src/ui/settings/folders/include-sub-folders-switch.tsx
 msgid "Include subfolders"
@@ -7823,10 +7848,6 @@ msgstr "等待回合结束"
 #: src/ui/settings/settings-tabs.tsx
 msgid "UI"
 msgstr "UI设置"
-
-#: src/ui/settings/settings-tabs.tsx
-msgid "Folders"
-msgstr "文件夹"
 
 #: src/ui/settings/settings-tabs.tsx
 msgid "Maps"

--- a/src/ui/translations/zh-TW/messages.po
+++ b/src/ui/translations/zh-TW/messages.po
@@ -2713,12 +2713,20 @@ msgid "No folders found."
 msgstr "未找到文件夾。"
 
 #: src/ui/demos/table/loading-demos-message.tsx
+msgid "Scanning archive {current} of {total}…"
+msgstr ""
+
+#: src/ui/demos/table/loading-demos-message.tsx
+msgid "Extracting demo {current} of {total} from archives…"
+msgstr ""
+
+#: src/ui/demos/table/loading-demos-message.tsx
 msgid "Loading demos…"
 msgstr "加載 demo 中…"
 
 #: src/ui/demos/table/loading-demos-message.tsx
-msgid "Loading {loadedDemoCount} of {demoToLoadCount} demos…"
-msgstr "{demoToLoadCount} 個 demo 已加載 {loadedDemoCount} 個…"
+msgid "Loading {current} of {total} demos…"
+msgstr ""
 
 #: src/ui/demos/table/no-demos.tsx
 msgid "No demos found with current filters."
@@ -7403,9 +7411,26 @@ msgctxt "Button"
 msgid "Add a folder"
 msgstr "增加一個文件夾"
 
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatic demo extraction from archives"
+msgstr ""
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Automatically extract demos contained in archives found in your folders when scanning for demos. Extracted demos are placed next to their archive."
+msgstr ""
+
+#: src/ui/settings/folders/demo-archive-extraction-settings.tsx
+msgid "Enabling automatic extraction has an impact on demo loading speed!"
+msgstr ""
+
 #: src/ui/settings/folders/folder-row.tsx
 msgid "This folder contains characters that will prevent demo playback when starting CS:GO! (not CS2)"
 msgstr "此文件夾包含在啟動CS:GO時阻止demo播放的字符！(不是CS2)"
+
+#: src/ui/settings/folders/folders-settings.tsx
+#: src/ui/settings/settings-tabs.tsx
+msgid "Folders"
+msgstr "文件夾"
 
 #: src/ui/settings/folders/include-sub-folders-switch.tsx
 msgid "Include subfolders"
@@ -7823,10 +7848,6 @@ msgstr ""
 #: src/ui/settings/settings-tabs.tsx
 msgid "UI"
 msgstr "UI設置"
-
-#: src/ui/settings/settings-tabs.tsx
-msgid "Folders"
-msgstr "文件夾"
 
 #: src/ui/settings/settings-tabs.tsx
 msgid "Maps"


### PR DESCRIPTION
## Summary

#1415 

Adds automatic extraction of demos contained in archive files when scanning folders. When enabled, CS Demo Manager unpacks demos found inside archives (`.zip`, `.gz`, `.bz2`) during the folder scan and loads them like any other demo. Extracted demos are written next to their source archive.

Extraction is **opt-in per format** via a new section in **Settings → Folders**, since unpacking archives adds overhead to demo loading.

## Notes
- Disabled by default — no behavior change unless a user opts in.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic extraction of demos from `.zip`, `.gz`, and `.bz2` during folder scans, before discovery. Controlled per-format in Settings → Folders via new switches; disabled by default.

- **New Features**
  - Extract demos from archives and write them next to the archive; `.zip` also extracts sibling `.dem.info` when present.
  - Skips already-extracted demos and duplicate flattened names across archives; uses temp files to avoid partial writes.
  - Three-step progress with counts and messages: Scanning archives → Extracting from archives → Loading demos.

- **Migration**
  - Settings schema v13 adds `autoExtractDemosFromArchives` (default: empty).
  - `FetchDemosProgress` now uses `LoadDemosProgress` with `{ step, current, total }`.

<sup>Written for commit d0f1c0e62eb95f9608570ed2c47a1921807b0899. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akiver/cs-demo-manager/pull/1426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



