### PR TITLE
feat: use free port automatically

### DIFF
--- a/cs2-server-plugin/cs2-server-plugin/main.cpp
+++ b/cs2-server-plugin/cs2-server-plugin/main.cpp
@@ -4,6 +4,8 @@
 #include <mutex>
 #include <queue>
 #include <sstream>
+#include <cstdlib>
+#include <string>
 #include <nlohmann/json.hpp>
 #include <easywsclient.hpp>
 #include "icvar.h"
@@ -455,9 +457,26 @@ void HandleWebSocketMessage(const std::string& message)
     }
 }
 
+// Must be kept in sync with DEFAULT_WEB_SOCKET_SERVER_PORT in src/server/port.ts.
+const int DEFAULT_WEB_SOCKET_SERVER_PORT = 4574;
+
+int GetWebSocketServerPort() {
+    const char* portValue = getenv("CSDM_WS_PORT");
+    if (portValue != NULL) {
+        int port = atoi(portValue);
+        if (port > 0) {
+            return port;
+        }
+    }
+
+    return DEFAULT_WEB_SOCKET_SERVER_PORT;
+}
+
 void ConnectToWebsocketServer() {
-    Log("Connecting to WebSocket server...");
-    ws = WebSocket::from_url("ws://localhost:4574?process=game");
+    int port = GetWebSocketServerPort();
+    string url = "ws://localhost:" + std::to_string(port) + "?process=game";
+    Log("Connecting to WebSocket server on port %d...", port);
+    ws = WebSocket::from_url(url);
     if (ws == NULL)
     {
         Log("Failed to connect to WebSocket server.");

--- a/csgo-server-plugin/csgo-server-plugin/main.cpp
+++ b/csgo-server-plugin/csgo-server-plugin/main.cpp
@@ -2,6 +2,8 @@
 #include <fstream>
 #include <mutex>
 #include <queue>
+#include <cstdlib>
+#include <string>
 #include <tier1.h>
 #include <easywsclient.hpp>
 #include <nlohmann/json.hpp>
@@ -253,9 +255,26 @@ void PlaybackFrame() {
     currentTick = newTick;
 }
 
+// Must be kept in sync with DEFAULT_WEB_SOCKET_SERVER_PORT in src/server/port.ts.
+const int DEFAULT_WEB_SOCKET_SERVER_PORT = 4574;
+
+int GetWebSocketServerPort() {
+    const char* portValue = getenv("CSDM_WS_PORT");
+    if (portValue != NULL) {
+        int port = atoi(portValue);
+        if (port > 0) {
+            return port;
+        }
+    }
+
+    return DEFAULT_WEB_SOCKET_SERVER_PORT;
+}
+
 void ConnectToWebsocketServer() {
-    Log("Connecting to WebSocket server...");
-    ws = WebSocket::from_url("ws://localhost:4574?process=game");
+    int port = GetWebSocketServerPort();
+    string url = "ws://localhost:" + std::to_string(port) + "?process=game";
+    Log("Connecting to WebSocket server on port %d...", port);
+    ws = WebSocket::from_url(url);
     if (ws == NULL)
     {
         Log("Failed to connect to WebSocket server.");

--- a/scripts/develop.mjs
+++ b/scripts/develop.mjs
@@ -4,7 +4,6 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 import fs from 'fs-extra';
-import { WebSocketServer as WSServer } from 'ws';
 import { createServer, createLogger } from 'vite-plus';
 import electronPath from 'electron';
 import esbuild from 'esbuild';
@@ -235,37 +234,8 @@ async function buildAndWatchMainProcessBundles() {
   });
 }
 
-async function assertWebSocketServerIsAvailable() {
-  const port = 4574;
-  return new Promise((resolve) => {
-    const server = new WSServer({
-      port,
-    });
-
-    server.on('error', (error) => {
-      if (error.code === 'EACCES') {
-        console.error(`You don't have permission to run the WebSocket server on port ${port}.`);
-      }
-      if (error.code === 'EADDRINUSE') {
-        console.error(
-          `A WebSocket server is already running on port ${port}. Please make sure to quit all running CS:DM application and retry.`,
-        );
-      } else {
-        console.error(error);
-      }
-      process.exit(1);
-    });
-
-    server.on('listening', () => {
-      server.close();
-      return resolve();
-    });
-  });
-}
-
 try {
   await fs.ensureDir(outFolderPath);
-  await assertWebSocketServerIsAvailable();
 
   await Promise.all([buildAndWatchRendererProcessBundle(), buildAndWatchMainProcessBundles(), copyDevRendererHtml()]);
   startElectron();

--- a/src/electron-main/main.ts
+++ b/src/electron-main/main.ts
@@ -25,6 +25,8 @@ import { updateSystemStartupBehavior } from 'csdm/electron-main/system-startup-b
 import { StartupBehavior } from 'csdm/common/types/startup-behavior';
 import { initialize } from './auto-updater';
 import { getSettingsSync } from 'csdm/node/settings/get-settings';
+import { resolveWebSocketServerPort } from './resolve-web-socket-server-port';
+import { WEB_SOCKET_SERVER_PORT_ENV_NAME } from 'csdm/server/port';
 
 process.on('uncaughtException', logger.error);
 process.on('unhandledRejection', logger.error);
@@ -97,6 +99,12 @@ async function start() {
   });
 
   await injectPathVariableIntoProcess();
+
+  // Resolve the WebSocket server port before starting any process so they all connect to the same port.
+  // It's exposed through an environment variable inherited by the server, renderer and main processes.
+  const webSocketServerPort = await resolveWebSocketServerPort();
+  process.env[WEB_SOCKET_SERVER_PORT_ENV_NAME] = String(webSocketServerPort);
+  logger.log(`WebSocket server port resolved to ${webSocketServerPort}`);
 
   if (IS_PRODUCTION) {
     createWebSocketServerProcess();

--- a/src/electron-main/resolve-web-socket-server-port.ts
+++ b/src/electron-main/resolve-web-socket-server-port.ts
@@ -1,0 +1,47 @@
+import net from 'node:net';
+import { DEFAULT_WEB_SOCKET_SERVER_PORT } from 'csdm/server/port';
+
+function getServerPort(server: net.Server): number {
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('Unable to read the resolved server port');
+  }
+
+  return address.port;
+}
+
+// Tries to listen on the given port the same way the WebSocket server does.
+function listen(port: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once('error', reject);
+    server.listen({ port }, () => {
+      const resolvedPort = getServerPort(server);
+      server.close(() => {
+        resolve(resolvedPort);
+      });
+    });
+  });
+}
+
+export async function resolveWebSocketServerPort(): Promise<number> {
+  try {
+    return await listen(DEFAULT_WEB_SOCKET_SERVER_PORT);
+  } catch (error) {
+    logger.warn(
+      `The default WebSocket server port ${DEFAULT_WEB_SOCKET_SERVER_PORT} is unavailable, resolving a free port`,
+    );
+    logger.warn(error);
+
+    try {
+      // Passing port 0 lets the OS assign an available port outside any reserved range.
+      return await listen(0);
+    } catch (fallbackError) {
+      logger.error('Unable to resolve a free WebSocket server port, falling back to the default port');
+      logger.error(fallbackError);
+
+      return DEFAULT_WEB_SOCKET_SERVER_PORT;
+    }
+  }
+}

--- a/src/electron-main/web-socket/web-socket-client.ts
+++ b/src/electron-main/web-socket/web-socket-client.ts
@@ -6,7 +6,7 @@ import type {
   MainServerMessageResponse,
 } from 'csdm/server/main-server-message-name';
 import type { MainClientMessageName } from 'csdm/server/main-client-message-name';
-import { WEB_SOCKET_SERVER_PORT } from 'csdm/server/port';
+import { getWebSocketServerPort } from 'csdm/server/port';
 import type { IdentifiableClientMessage } from 'csdm/server/identifiable-client-message';
 import { SharedServerMessageName } from 'csdm/server/shared-server-message-name';
 import type { MainMessageHandlers } from 'csdm/server/handlers/main-handlers-mapping';
@@ -103,7 +103,7 @@ export class WebSocketClient {
 
   private connect = () => {
     logger.log('WS:: connecting to server');
-    const url = `ws://localhost:${WEB_SOCKET_SERVER_PORT}?process=main`;
+    const url = `ws://localhost:${getWebSocketServerPort()}?process=main`;
     this.socket = new WebSocket(url);
     this.socket.addEventListener('open', this.onConnect);
     this.socket.addEventListener('error', this.onDisconnect);

--- a/src/node/counter-strike/launcher/start-counter-strike-with-hlae.ts
+++ b/src/node/counter-strike/launcher/start-counter-strike-with-hlae.ts
@@ -20,6 +20,7 @@ import { getFfmpegExecutablePath } from 'csdm/node/video/ffmpeg/ffmpeg-location'
 import { FfmpegNotInstalled } from 'csdm/node/video/errors/ffmpeg-not-installed';
 import { DisplayMode } from 'csdm/common/types/display-mode';
 import { enableFullscreenWindowed } from './video-config-file';
+import { getWebSocketServerPort, WEB_SOCKET_SERVER_PORT_ENV_NAME } from 'csdm/server/port';
 
 export type HlaeOptions = {
   game: Game;
@@ -76,7 +77,9 @@ async function startHlae({ command, signal, game }: StartHlaeOptions) {
   logger.debug('Starting HLAE with command', command);
 
   return new Promise<void>((resolve, reject) => {
-    const hlaeProcess = exec(command, { windowsHide: true }, (error, stdout, stderr) => {
+    // Forward the resolved WebSocket server port so the game server plugin can connect to the WebSocket server.
+    const env = { ...process.env, [WEB_SOCKET_SERVER_PORT_ENV_NAME]: String(getWebSocketServerPort()) };
+    const hlaeProcess = exec(command, { windowsHide: true, env }, (error, stdout, stderr) => {
       if (signal?.aborted) {
         return;
       }

--- a/src/node/counter-strike/launcher/start-counter-strike.ts
+++ b/src/node/counter-strike/launcher/start-counter-strike.ts
@@ -27,6 +27,7 @@ import { getCsgoFolderPath } from '../get-csgo-folder-path';
 import path from 'node:path';
 import { DisplayMode } from 'csdm/common/types/display-mode';
 import { enableFullscreenWindowed } from './video-config-file';
+import { getWebSocketServerPort, WEB_SOCKET_SERVER_PORT_ENV_NAME } from 'csdm/server/port';
 
 export type StartCounterStrikeOptions = {
   demoPath?: string;
@@ -260,7 +261,11 @@ echo "CS:DM config loaded"
 
   return new Promise<void>((resolve, reject) => {
     const startTime = Date.now();
-    const gameProcess = exec(command, { windowsHide: true });
+    // Forward the resolved WebSocket server port so the game server plugin can connect to the WebSocket server.
+    const gameProcess = exec(command, {
+      windowsHide: true,
+      env: { ...process.env, [WEB_SOCKET_SERVER_PORT_ENV_NAME]: String(getWebSocketServerPort()) },
+    });
     const chunks: string[] = [];
     gameProcess.stdout?.on('data', (data: string) => {
       chunks.push(data);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -44,6 +44,7 @@ import { getImageInformation } from 'csdm/node/filesystem/get-image-information'
 import { readImageFile } from 'csdm/node/filesystem/image';
 import { writeJsonFile } from 'csdm/node/filesystem/write-json-file';
 import { ErrorCode } from 'csdm/common/error-code';
+import { getWebSocketServerPort } from 'csdm/server/port';
 
 window.addEventListener('error', onWindowError);
 window.addEventListener('unhandledrejection', (error) => {
@@ -61,6 +62,7 @@ function handleError(error: unknown) {
 const api: PreloadApi = {
   logger,
   ADDITIONAL_ARGUMENTS: process.argv,
+  WEB_SOCKET_SERVER_PORT: getWebSocketServerPort(),
   IMAGES_FOLDER_PATH: path.join(getStaticFolderPath(), 'images'),
   getAppInformation,
   getStartupArguments: () => {

--- a/src/server/port.ts
+++ b/src/server/port.ts
@@ -1,1 +1,14 @@
-export const WEB_SOCKET_SERVER_PORT = 4574;
+// Default port used by the WebSocket server.
+// If the port is already in use, the main process will resolve a free port at startup and expose it to the other
+// processes through the CSDM_WS_PORT environment variable.
+// ! Must be kept in sync with DEFAULT_WEB_SOCKET_SERVER_PORT in cs2-server-plugin/main.cpp and csgo-server-plugin/main.cpp.
+export const DEFAULT_WEB_SOCKET_SERVER_PORT = 4574;
+
+// Name of the environment variable holding the WebSocket server port resolved by the main process.
+export const WEB_SOCKET_SERVER_PORT_ENV_NAME = 'CSDM_WS_PORT';
+
+export function getWebSocketServerPort(): number {
+  const port = Number(process.env[WEB_SOCKET_SERVER_PORT_ENV_NAME]);
+
+  return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : DEFAULT_WEB_SOCKET_SERVER_PORT;
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -11,7 +11,7 @@ import { rendererHandlers } from 'csdm/server/handlers/renderer-handlers-mapping
 import { mainHandlers } from 'csdm/server/handlers/main-handlers-mapping';
 import type { MainClientMessageName } from './main-client-message-name';
 import type { RendererClientMessageName } from './renderer-client-message-name';
-import { WEB_SOCKET_SERVER_PORT } from './port';
+import { getWebSocketServerPort } from './port';
 import type { SharedServerMessagePayload } from './shared-server-message-name';
 import { SharedServerMessageName } from './shared-server-message-name';
 import type { IdentifiableClientMessage } from './identifiable-client-message';
@@ -86,7 +86,7 @@ class WebSocketServer {
 
   constructor() {
     this.server = new WSServer({
-      port: WEB_SOCKET_SERVER_PORT,
+      port: getWebSocketServerPort(),
     });
 
     this.server.on('listening', this.onServerCreated);
@@ -150,7 +150,7 @@ class WebSocketServer {
   };
 
   private onServerCreated = () => {
-    logger.debug(`WS:: server listening on port ${WEB_SOCKET_SERVER_PORT}`);
+    logger.debug(`WS:: server listening on port ${getWebSocketServerPort()}`);
   };
 
   private onConnection = (webSocket: WebSocket, request: IncomingMessage): void => {

--- a/src/ui/bootstrap/web-socket-provider.tsx
+++ b/src/ui/bootstrap/web-socket-provider.tsx
@@ -27,7 +27,10 @@ export function WebSocketProvider({ children }: Props) {
 
       const onConnectionError = (event: CloseEvent) => {
         const code = event.code;
-        setError(t`The connection to the WebSocket server failed with code ${code}.`);
+        const port = window.csdm.WEB_SOCKET_SERVER_PORT;
+        setError(
+          t`The connection to the local server on port ${port} failed with code ${code}. The port might be reserved or blocked by another application. Restarting your computer or freeing the port may fix the issue.`,
+        );
         setStatus(Status.Error);
       };
 

--- a/src/ui/translations/en/messages.po
+++ b/src/ui/translations/en/messages.po
@@ -390,8 +390,8 @@ msgid "Counter-Strike starting…"
 msgstr "Counter-Strike starting…"
 
 #: src/ui/bootstrap/web-socket-provider.tsx
-msgid "The connection to the WebSocket server failed with code {code}."
-msgstr "The connection to the WebSocket server failed with code {code}."
+msgid "The connection to the local server on port {port} failed with code {code}. The port might be reserved or blocked by another application. Restarting your computer or freeing the port may fix the issue."
+msgstr "The connection to the local server on port {port} failed with code {code}. The port might be reserved or blocked by another application. Restarting your computer or freeing the port may fix the issue."
 
 #: src/ui/bootstrap/web-socket-provider.tsx
 msgid "An error occurred connecting to the WebSocket server."

--- a/src/ui/web-socket-client.ts
+++ b/src/ui/web-socket-client.ts
@@ -1,6 +1,5 @@
 import type { RendererMessageHandlers } from 'csdm/server/handlers/renderer-handlers-mapping';
 import type { IdentifiableClientMessage } from 'csdm/server/identifiable-client-message';
-import { WEB_SOCKET_SERVER_PORT } from 'csdm/server/port';
 import type { RendererClientMessageName } from 'csdm/server/renderer-client-message-name';
 import type { RendererServerMessagePayload, RendererServerMessageName } from 'csdm/server/renderer-server-message-name';
 import { SharedServerMessageName } from 'csdm/server/shared-server-message-name';
@@ -96,7 +95,7 @@ export class WebSocketClient {
 
   private connect = () => {
     logger.log('WS:: connecting to server');
-    const url = `ws://localhost:${WEB_SOCKET_SERVER_PORT}?process=renderer`;
+    const url = `ws://localhost:${window.csdm.WEB_SOCKET_SERVER_PORT}?process=renderer`;
     this.socket = new WebSocket(url);
     this.socket.addEventListener('open', this.onConnect);
     this.socket.addEventListener('close', this.onDisconnect);

--- a/types/window-preload.d.ts
+++ b/types/window-preload.d.ts
@@ -37,6 +37,7 @@ declare global {
     unknownImageFilePath: string;
     IMAGES_FOLDER_PATH: string;
     ADDITIONAL_ARGUMENTS: string[];
+    WEB_SOCKET_SERVER_PORT: number;
     getStartupArguments: () => Promise<Argument[]>;
     getTheme: () => Promise<ThemeName>;
     getWebFilePath: (file: File) => string;


### PR DESCRIPTION
ref #1422

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically selects a free WebSocket port at startup and shares it across all processes and game plugins to avoid conflicts on 4574. Addresses #1422 by preventing connection failures when the default port is taken and improving error messages.

- **New Features**
  - Main process resolves the port: try 4574, else get a free OS port, else fall back to 4574.
  - Exposes the chosen port via `CSDM_WS_PORT`; added `getWebSocketServerPort`, `DEFAULT_WEB_SOCKET_SERVER_PORT`, and `WEB_SOCKET_SERVER_PORT_ENV_NAME`.
  - Server, main, and renderer connect using the resolved port; preload exposes it as `window.csdm.WEB_SOCKET_SERVER_PORT`.
  - CS:GO/CS2 server plugins read `CSDM_WS_PORT` and connect to the resolved port; added logs showing the port.
  - Game and HLAE launchers forward `CSDM_WS_PORT` to child processes.
  - UI error now mentions the actual port used; removed the dev-time fixed-port check in `scripts/develop.mjs`.

<sup>Written for commit 6d7598d97bcb9824d40b602df52948ce878d7a33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akiver/cs-demo-manager/pull/1428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

