### PR TITLE
fix(cs2-plugin): update vtable offsets for the latest CS2 update

### DIFF
--- a/cs2-server-plugin/cs2-server-plugin/Makefile
+++ b/cs2-server-plugin/cs2-server-plugin/Makefile
@@ -17,7 +17,8 @@ INCLUDE_DIRS =  -I./deps/json/include \
 				-I./deps/easywsclient \
 				-I./deps/hl2sdk/public \
 				-I./deps/hl2sdk/public/tier0 \
-				-I./deps/hl2sdk/public/tier1
+				-I./deps/hl2sdk/public/tier1 \
+				-I./deps/hl2sdk/public/mathlib
 
 LIB_DIRS = -L./deps/hl2sdk/lib/linux64
 LIBS = -ldl -ltier0 -l:tier1.a

--- a/cs2-server-plugin/cs2-server-plugin/cdll_interfaces.h
+++ b/cs2-server-plugin/cs2-server-plugin/cdll_interfaces.h
@@ -11,23 +11,25 @@ abstract_class IDemoPlayer
 {
 public:
     virtual void _Unknown_000(void) = 0;
-    virtual void _Unknown_001(void) = 0;
 #if defined _WIN32
-    virtual int _Unknown_002(void) = 0;
-    virtual int _GetDemoTick(void) = 0; // :003 see :004
+    virtual void _Unknown_001(void) = 0;
 #else
-    virtual int _Unknown_002(void) = 0;
-    virtual int _Unknown_003(void) = 0;
+    // Linux (Itanium ABI): the virtual destructor uses two vtable slots (complete +
+    // deleting) instead of one on MSVC, so every method below is one slot higher.
+    virtual void _Unknown_001(void) = 0;
+    virtual void _Unknown_002(void) = 0;
 #endif
-    virtual int GetDemoTick(void) = 0; //:004 points to the same function as :003 on Windows
+    virtual int GetDemoStartTick(void) = 0; // win:002 linux:003
+    virtual int GetDemoTick(void) = 0; // win:003 linux:004
+    virtual int _Unknown_004(void) = 0;
     virtual int _Unknown_005(void) = 0;
     virtual int _Unknown_006(void) = 0;
     virtual int _Unknown_007(void) = 0;
     virtual int _Unknown_008(void) = 0;
     virtual int _Unknown_009(void) = 0;
     virtual int _Unknown_010(void) = 0;
-    virtual bool IsPlayingDemo(void) = 0; //:011
-    virtual bool IsDemoPaused(void) = 0; //:012
+    virtual bool IsPlayingDemo(void) = 0; // win:011 linux:012
+    virtual bool IsDemoPaused(void) = 0; // win:012 linux:013
 };
 
 
@@ -77,15 +79,15 @@ public:
     virtual void _Unknown_040(void) = 0;
     virtual void _Unknown_041(void) = 0;
     virtual bool IsPlayingDemo(void) = 0; //:042
-    virtual void _Unknown_043(void) = 0; // Demo related
-    virtual bool IsRecordingDemo(void) = 0; //:044
-    virtual void _Unknown_045(void) = 0; // Demo related
-    virtual void _Unknown_046(void) = 0;
+    virtual void _Unknown_043(void) = 0; // slot inserted by the CS2 update; shifts everything below +1
+    virtual void _Unknown_044(void) = 0; // Demo related
+    virtual bool IsRecordingDemo(void) = 0; //:045
+    virtual void _Unknown_046(void) = 0; // Demo related
     virtual void _Unknown_047(void) = 0;
     virtual void _Unknown_048(void) = 0;
     virtual void _Unknown_049(void) = 0;
-    virtual void ExecuteClientCmd(int iUnk0MaybeSplitScreenSlotSetTo0, const char* pszCommands, bool bUnk2SetToTrue) = 0; //:050
-    virtual void _Unknown_051(void) = 0;
+    virtual void _Unknown_050(void) = 0;
+    virtual void ExecuteClientCmd(int iUnk0MaybeSplitScreenSlotSetTo0, const char* pszCommands, bool bUnk2SetToTrue) = 0; //:051
     virtual void _Unknown_052(void) = 0;
     virtual void _Unknown_053(void) = 0;
     virtual void _Unknown_054(void) = 0;
@@ -94,15 +96,16 @@ public:
     virtual void _Unknown_057(void) = 0;
     virtual void _Unknown_058(void) = 0;
     virtual void _Unknown_059(void) = 0;
-    virtual void GetScreenSize(int& width, int& height) = 0; //:060
-    virtual void _Unknown_061(void) = 0;
+    virtual void _Unknown_060(void) = 0;
+    virtual void GetScreenSize(int& width, int& height) = 0; //:061
     virtual void _Unknown_062(void) = 0;
-    virtual char const* GetLevelName(void) = 0; //:063
-    virtual char const* GetLevelNameShort(void) = 0; //:064
-    virtual void _Unknown_065(void) = 0;
+    virtual void _Unknown_063(void) = 0;
+    virtual char const* GetLevelName(void) = 0; //:064
+    virtual char const* GetLevelNameShort(void) = 0; //:065
     virtual void _Unknown_066(void) = 0;
     virtual void _Unknown_067(void) = 0;
-    virtual IDemoPlayer* GetDemoPlayer(void) = 0; //:068
+    virtual void _Unknown_068(void) = 0;
+    virtual IDemoPlayer* GetDemoPlayer(void) = 0; //:069
 };
 
 enum class ClientFrameStage_t : int

--- a/cs2-server-plugin/cs2-server-plugin/cs2-server-plugin.vcxproj
+++ b/cs2-server-plugin/cs2-server-plugin/cs2-server-plugin.vcxproj
@@ -129,7 +129,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;COMPILER_MSVC;COMPILER_MSVC64;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>Default</ConformanceMode>
-      <AdditionalIncludeDirectories>deps/hl2sdk/public/tier1;deps/hl2sdk/public/tier0;deps/hl2sdk/public;deps/json/include;deps/easywsclient;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>deps/hl2sdk/public/tier1;deps/hl2sdk/public/tier0;deps/hl2sdk/public;deps/hl2sdk/public/mathlib;deps/json/include;deps/easywsclient;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <DisableSpecificWarnings>4146</DisableSpecificWarnings>
     </ClCompile>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cs-demo-manager",
-  "version": "3.19.3",
+  "version": "3.20.0",
   "description": "Companion application for your Counter-Strike demos.",
   "keywords": [
     "CS",


### PR DESCRIPTION
The CS2 update after v3.20.0 shifted the engine and demo-player vtables again:

The demo/engine vtable slots differ per platform, so I derived the correct slots/offsets from the actual game binary rather than guessing:                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                    
  - Reconstructed the `CDemoPlayer` vtable from the Linux libengine2.so (build 24134959). Linux Source2 binaries retain RTTI/symbols (Windows PE is stripped), so the class was located by its RTTI name string and its vtable walked via relocations, then each slot disassembled to identify the methods            
  (`GetDemoStartTick`/`GetDemoTick` are trivial int-getters, `IsPlayingDemo`/`IsDemoPaused` are bool-getters).                                                                                                                                                                                                              
  - The cause of the split between platforms is caused by the vtable slots 0–1 being two Itanium destructors (complete + deleting). MSVC represents a virtual destructor with a single slot, so every method after it is +1 on Linux. That's why `GetDemoTick` is slot 3 on Windows / 4 on Linux, `IsPlayingDemo` 11/12, etc. The engine interface     
  (`ISource2EngineToClient`) has no such destructor, so it is identical on both platforms.                                                                                                                                                                                                                            
  - Confirmed the header compiles to those exact slots by preprocessing it with g++ both with and without -D_WIN32 and reading the emitted call/jmp *N(%rax) offsets (e.g. `GetDemoTick` → *24 (slot 3) on Windows, *32 (slot 4) on Linux).                                                                           
  - Validated end-to-end with an in-game demo playback on Windows: `GetDemoTick` returned monotonically increasing ticks and tick-keyed actions fired in order — which would not happen if the slot were off (it would hit `GetDemoStartTick`, a constant).                                                             
                                                                                                                                                                                                                                                                                                                    Why mathlib was added to the include paths                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  - Bumping hl2sdk pulls in a newer `public/tier1/convar.h` that does a bare `#include "vectorws.h"`. That header only exists under `public/mathlib/`, so without that directory on the include path the build fails immediately with `C1083: Cannot open include file: 'vectorws.h'`. Adding `deps/hl2sdk/public/mathlib` to the vcxproj and Makefile resolves it.

The prebuilt server.dll / libserver.so are left untouched on purpose - the repo's CI (build_cs_plugins.yml) rebuilds and commits them.

I tested the these changes on Windows only and found everything to be working. I can get see about getting a Linux instance up and running to test on if no-one else beats me to it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken demo playback and client command calls by updating vtable offsets for the latest CS2 update, and bumps `hl2sdk` to keep the build green. Adds the required `mathlib` include path.

- **Bug Fixes**
  - Updated `ISource2EngineToClient` vtable: a new slot after `IsPlayingDemo` shifts `ExecuteClientCmd` to :051 and `GetDemoPlayer` to :069.
  - Rebuilt `IDemoPlayer` vtable: added `GetDemoStartTick`, removed the old Windows duplicate, and accounted for the Linux Itanium two-slot destructor. `GetDemoTick` is now win:003 / linux:004; `IsPlayingDemo` is win:011 / linux:012.
  - Verified on Windows with in-game demo playback (ticks increase as expected).

- **Dependencies**
  - Bumped `deps/hl2sdk` to `5f891c90` (ICvar changes). Added `deps/hl2sdk/public/mathlib` to include paths to satisfy `vectorws.h` includes (Makefile + `.vcxproj`).

<sup>Written for commit f24e412521a43d9dd6394c87464f4adc0217ed09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akiver/cs-demo-manager/pull/1432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

