### PR TITLE
feat(demos): support .zst compressed demos

### DIFF
--- a/src/common/types/archive-format.ts
+++ b/src/common/types/archive-format.ts
@@ -4,8 +4,29 @@ export const ArchiveFormat = {
   Zip: 'zip',
   Gz: 'gz',
   Bz2: 'bz2',
+  Zst: 'zst',
 } as const;
 
 export type ArchiveFormat = (typeof ArchiveFormat)[keyof typeof ArchiveFormat];
 
-export const supportedArchiveFormats: ArchiveFormat[] = [ArchiveFormat.Zip, ArchiveFormat.Gz, ArchiveFormat.Bz2];
+export const supportedArchiveFormats: ArchiveFormat[] = [
+  ArchiveFormat.Zip,
+  ArchiveFormat.Gz,
+  ArchiveFormat.Bz2,
+  ArchiveFormat.Zst,
+];
+
+// Archive formats holding a single compressed stream, unlike .zip which may hold several files.
+export type SingleStreamArchiveFormat = Exclude<ArchiveFormat, typeof ArchiveFormat.Zip>;
+
+const singleStreamArchiveFormats: SingleStreamArchiveFormat[] = [
+  ArchiveFormat.Gz,
+  ArchiveFormat.Bz2,
+  ArchiveFormat.Zst,
+];
+
+export function isSingleStreamArchiveFormat(value: string): value is SingleStreamArchiveFormat {
+  return singleStreamArchiveFormats.some((format) => {
+    return format === value;
+  });
+}

--- a/src/node/demo/create-decompress-stream.ts
+++ b/src/node/demo/create-decompress-stream.ts
@@ -1,0 +1,16 @@
+import zlib from 'node:zlib';
+import bz2 from 'unbzip2-stream';
+import { ArchiveFormat, type SingleStreamArchiveFormat } from 'csdm/common/types/archive-format';
+
+// Decompression stream of the archive formats holding a single compressed stream.
+// .zip is not handled here, it may hold several files and requires a dedicated reader.
+export function createDecompressStream(format: SingleStreamArchiveFormat): NodeJS.ReadWriteStream {
+  switch (format) {
+    case ArchiveFormat.Gz:
+      return zlib.createGunzip();
+    case ArchiveFormat.Bz2:
+      return bz2();
+    case ArchiveFormat.Zst:
+      return zlib.createZstdDecompress();
+  }
+}

--- a/src/node/demo/demo-archive-extraction.test.ts
+++ b/src/node/demo/demo-archive-extraction.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vite-plus/test';
+import path from 'node:path';
+import os from 'node:os';
+import zlib from 'node:zlib';
+import fs from 'node:fs/promises';
+import { extractDemosFromArchive, getDemosToExtractFromArchive } from './demo-archive-extraction';
+
+describe('Demo archive extraction', () => {
+  const demoContent = 'PBDEMS2 fake demo content';
+
+  // Creates the archive in a temporary folder deleted once the test is done, whether it succeeded or not.
+  async function withArchive(fileName: string, bytes: Buffer, test: (archivePath: string) => Promise<void>) {
+    const folderPath = await fs.mkdtemp(path.join(os.tmpdir(), 'csdm-archive-'));
+    try {
+      const archivePath = path.join(folderPath, fileName);
+      await fs.writeFile(archivePath, bytes);
+      await test(archivePath);
+    } finally {
+      await fs.rm(folderPath, { recursive: true, force: true });
+    }
+  }
+
+  it('given a .zst archive, when listing its demos, then the demo is queued next to the archive', async () => {
+    // Given
+    const archiveBytes = zlib.zstdCompressSync(Buffer.from(demoContent));
+
+    await withArchive('match.dem.zst', archiveBytes, async (archivePath) => {
+      // When
+      const demosToExtract = await getDemosToExtractFromArchive(archivePath);
+
+      // Then
+      expect(demosToExtract).toHaveLength(1);
+      expect(demosToExtract[0].destinationPath).toBe(archivePath.slice(0, -'.zst'.length));
+    });
+  });
+
+  it('given a .zst archive, when extracting it, then the demo is decompressed', async () => {
+    // Given
+    const archiveBytes = zlib.zstdCompressSync(Buffer.from(demoContent));
+
+    await withArchive('match.dem.zst', archiveBytes, async (archivePath) => {
+      // When
+      const demosToExtract = await getDemosToExtractFromArchive(archivePath);
+      await extractDemosFromArchive(archivePath, demosToExtract);
+
+      // Then
+      const extractedContent = await fs.readFile(demosToExtract[0].destinationPath, 'utf8');
+      expect(extractedContent).toBe(demoContent);
+    });
+  });
+
+  it('given a .gz archive, when extracting it, then the demo is decompressed', async () => {
+    // Given
+    const archiveBytes = zlib.gzipSync(Buffer.from(demoContent));
+
+    await withArchive('match.dem.gz', archiveBytes, async (archivePath) => {
+      // When
+      const demosToExtract = await getDemosToExtractFromArchive(archivePath);
+      await extractDemosFromArchive(archivePath, demosToExtract);
+
+      // Then
+      const extractedContent = await fs.readFile(demosToExtract[0].destinationPath, 'utf8');
+      expect(extractedContent).toBe(demoContent);
+    });
+  });
+
+  it('given a .zst archive that does not hold a demo, when listing its demos, then nothing is queued', async () => {
+    // Given
+    const archiveBytes = zlib.zstdCompressSync(Buffer.from(demoContent));
+
+    await withArchive('notes.txt.zst', archiveBytes, async (archivePath) => {
+      // When
+      const demosToExtract = await getDemosToExtractFromArchive(archivePath);
+
+      // Then
+      expect(demosToExtract).toHaveLength(0);
+    });
+  });
+
+  it('given a .zst archive already extracted, when listing its demos, then nothing is queued', async () => {
+    // Given
+    const archiveBytes = zlib.zstdCompressSync(Buffer.from(demoContent));
+
+    await withArchive('match.dem.zst', archiveBytes, async (archivePath) => {
+      await fs.writeFile(archivePath.slice(0, -'.zst'.length), demoContent);
+
+      // When
+      const demosToExtract = await getDemosToExtractFromArchive(archivePath);
+
+      // Then
+      expect(demosToExtract).toHaveLength(0);
+    });
+  });
+
+  it('given a corrupted .zst archive, when extracting it, then it throws and leaves no temporary file', async () => {
+    // Given
+    const archiveBytes = Buffer.from('not a zstd archive');
+
+    await withArchive('match.dem.zst', archiveBytes, async (archivePath) => {
+      // When
+      const demosToExtract = await getDemosToExtractFromArchive(archivePath);
+      const extraction = extractDemosFromArchive(archivePath, demosToExtract);
+
+      // Then
+      await expect(extraction).rejects.toThrow();
+      const fileNames = await fs.readdir(path.dirname(archivePath));
+      expect(fileNames).toStrictEqual(['match.dem.zst']);
+    });
+  });
+});

--- a/src/node/demo/demo-archive-extraction.ts
+++ b/src/node/demo/demo-archive-extraction.ts
@@ -1,14 +1,14 @@
 import path from 'node:path';
-import zlib from 'node:zlib';
 import { pipeline } from 'node:stream/promises';
 import { createReadStream, createWriteStream } from 'node:fs';
 import fs from 'fs-extra';
 import StreamZip from 'node-stream-zip';
-import bz2 from 'unbzip2-stream';
-import type { ArchiveFormat } from 'csdm/common/types/archive-format';
+import { type ArchiveFormat, isSingleStreamArchiveFormat } from 'csdm/common/types/archive-format';
+import { createDecompressStream } from './create-decompress-stream';
 
 export type DemoArchiveEntry = {
-  // Name (path) of the .dem entry inside the archive. For single-stream archives (.gz/.bz2) it's the demo file name.
+  // Name (path) of the .dem entry inside the archive. For single-stream archives (.gz/.bz2/.zst) it's the demo
+  // file name.
   entryName: string;
   // Path where the demo is extracted on the filesystem, flat next to the archive.
   destinationPath: string;
@@ -75,8 +75,8 @@ export async function getDemosToExtractFromArchive(
     return demosToExtract;
   }
 
-  // .gz/.bz2 hold a single compressed demo; its extracted name is the archive name minus the compression extension
-  // (e.g. match.dem.gz -> match.dem).
+  // .gz/.bz2/.zst hold a single compressed demo; its extracted name is the archive name minus the compression
+  // extension (e.g. match.dem.gz -> match.dem).
   const destinationPath = archivePath.slice(0, -extension.length);
   const isDemFile = destinationPath.toLowerCase().endsWith('.dem');
   const isQueued = queuedDestinationPaths.has(destinationPath);
@@ -127,7 +127,13 @@ export async function extractDemosFromArchive(
 
   const [{ destinationPath }] = demosToExtract;
   onExtractingDemo?.();
-  const decompressStream = extension === '.bz2' ? bz2() : zlib.createGunzip();
+  const format = extension.slice(1);
+  if (!isSingleStreamArchiveFormat(format)) {
+    throw new Error(`Unsupported archive format ${extension}`);
+  }
+
+  const decompressStream = createDecompressStream(format);
+
   const tempDestinationPath = `${destinationPath}.tmp`;
   try {
     await pipeline(createReadStream(archivePath), decompressStream, createWriteStream(tempDestinationPath));

--- a/src/node/download/get-archive-format-from-demo-url.test.ts
+++ b/src/node/download/get-archive-format-from-demo-url.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { ArchiveFormat } from 'csdm/common/types/archive-format';
+import { getArchiveFormatFromDemoUrl } from './get-archive-format-from-demo-url';
+
+describe('Get archive format from demo URL', () => {
+  it('given a URL without query parameters, when getting its archive format, then the format is returned', () => {
+    // Given
+    const demoUrls = [
+      'https://host.com/match.dem.zst',
+      'https://host.com/match.dem.gz',
+      'https://host.com/match.dem.bz2',
+      'https://host.com/match.zip',
+    ];
+
+    // When
+    const formats = demoUrls.map(getArchiveFormatFromDemoUrl);
+
+    // Then
+    expect(formats).toStrictEqual([ArchiveFormat.Zst, ArchiveFormat.Gz, ArchiveFormat.Bz2, ArchiveFormat.Zip]);
+  });
+
+  it('given a signed URL holding query parameters, when getting its archive format, then they are ignored', () => {
+    // Given
+    const demoUrl = 'https://host.com/match.dem.zst?token=abc&expires=1';
+
+    // When
+    const format = getArchiveFormatFromDemoUrl(demoUrl);
+
+    // Then
+    expect(format).toBe(ArchiveFormat.Zst);
+  });
+
+  it('given a query parameter holding another extension, when getting the format, then the pathname wins', () => {
+    // Given
+    const demoUrl = 'https://host.com/folder.zip/match.dem.zst?file=demo.zip';
+
+    // When
+    const format = getArchiveFormatFromDemoUrl(demoUrl);
+
+    // Then
+    expect(format).toBe(ArchiveFormat.Zst);
+  });
+
+  it('given a URL holding a fragment, when getting its archive format, then it is ignored', () => {
+    // Given
+    const demoUrl = 'https://host.com/match.dem.zst#fragment';
+
+    // When
+    const format = getArchiveFormatFromDemoUrl(demoUrl);
+
+    // Then
+    expect(format).toBe(ArchiveFormat.Zst);
+  });
+
+  it('given a URL holding an uppercase extension, when getting its archive format, then the case is ignored', () => {
+    // Given
+    const demoUrl = 'https://host.com/MATCH.DEM.ZST';
+
+    // When
+    const format = getArchiveFormatFromDemoUrl(demoUrl);
+
+    // Then
+    expect(format).toBe(ArchiveFormat.Zst);
+  });
+
+  it('given a URL that is not a supported archive, when getting its archive format, then undefined is returned', () => {
+    // Given
+    const demoUrls = [
+      'https://host.com/match.dem',
+      'https://host.com/match.dem.rar?token=abc',
+      'https://host.com/',
+      '',
+    ];
+
+    // When
+    const formats = demoUrls.map(getArchiveFormatFromDemoUrl);
+
+    // Then
+    expect(formats).toStrictEqual([undefined, undefined, undefined, undefined]);
+  });
+});

--- a/src/node/download/get-archive-format-from-demo-url.ts
+++ b/src/node/download/get-archive-format-from-demo-url.ts
@@ -1,0 +1,14 @@
+import type { ArchiveFormat } from 'csdm/common/types/archive-format';
+import { supportedArchiveFormats } from 'csdm/common/types/archive-format';
+
+// Returns the archive format a demo URL points to, undefined when it's not a supported archive.
+// The format is detected from the URL's pathname because download links may hold query parameters, for example
+// signed URLs (i.e. https://host/match.dem.zst?token=abc).
+export function getArchiveFormatFromDemoUrl(demoUrl: string): ArchiveFormat | undefined {
+  const url = URL.parse(demoUrl);
+  const pathname = (url?.pathname ?? demoUrl).toLowerCase();
+
+  return supportedArchiveFormats.find((format) => {
+    return pathname.endsWith(`.${format}`);
+  });
+}

--- a/src/server/download-queue.ts
+++ b/src/server/download-queue.ts
@@ -1,9 +1,7 @@
 import fs from 'fs-extra';
 import { pipeline } from 'node:stream';
 import { Client, interceptors } from 'undici';
-import b2 from 'unbzip2-stream';
 import unzipper from 'unzipper';
-import zlib from 'node:zlib';
 import path from 'node:path';
 import util from 'node:util';
 import { assertDownloadFolderIsValid } from 'csdm/node/download/assert-download-folder-is-valid';
@@ -22,7 +20,25 @@ import { WriteDemoInfoFileError } from 'csdm/node/download/errors/write-info-fil
 import { insertDownloadHistory } from 'csdm/node/database/download-history/insert-download-history';
 import { InvalidDemoHeader } from 'csdm/node/demo/errors/invalid-demo-header';
 import { insertDemos } from 'csdm/node/database/demos/insert-demos';
+import { ArchiveFormat } from 'csdm/common/types/archive-format';
+import { getArchiveFormatFromDemoUrl } from 'csdm/node/download/get-archive-format-from-demo-url';
+import { createDecompressStream } from 'csdm/node/demo/create-decompress-stream';
 const streamPipeline = util.promisify(pipeline);
+
+// Stream decompressing the downloaded demo on the fly.
+function createDemoTransformStream(demoUrl: string): NodeJS.WritableStream {
+  const archiveFormat = getArchiveFormatFromDemoUrl(demoUrl);
+  if (archiveFormat === undefined) {
+    throw new Error('Unsupported demo archive');
+  }
+
+  // Unlike the other formats a .zip may hold several files, only the first one is extracted.
+  if (archiveFormat === ArchiveFormat.Zip) {
+    return unzipper.ParseOne();
+  }
+
+  return createDecompressStream(archiveFormat);
+}
 
 class DownloadDemoQueue {
   private downloads: Download[] = [];
@@ -166,7 +182,8 @@ class DownloadDemoQueue {
       const url = new URL(currentDownload.demoUrl);
       const client = new Client(url.origin).compose(interceptors.redirect({ maxRedirections: 1 }));
       const response = await client.request({
-        path: url.pathname,
+        // Keep the query parameters, download links may be signed URLs that require them.
+        path: `${url.pathname}${url.search}`,
         signal: controller.signal,
         method: 'GET',
       });
@@ -209,17 +226,7 @@ class DownloadDemoQueue {
       });
 
       const out = fs.createWriteStream(demoPath);
-      let transformStream: NodeJS.WritableStream;
-      const { demoUrl } = currentDownload;
-      if (demoUrl.endsWith('.gz')) {
-        transformStream = zlib.createGunzip();
-      } else if (demoUrl.endsWith('.bz2')) {
-        transformStream = b2();
-      } else if (demoUrl.endsWith('.zip')) {
-        transformStream = unzipper.ParseOne();
-      } else {
-        throw new Error('Unsupported demo archive');
-      }
+      const transformStream = createDemoTransformStream(currentDownload.demoUrl);
 
       await streamPipeline(response.body, transformStream, out);
       if (currentDownload.source === DownloadSource.Valve) {


### PR DESCRIPTION
Add Zstandard to the archive formats that can be automatically extracted when scanning demo folders and decompress .zst demos downloaded from third-party providers. Decompression relies on Node's built-in zstd support.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for `.zst`-compressed demos in scans and downloads. Improves URL-based archive detection and preserves query params so signed URLs work.

- New Features
  - Added `Zst` to `ArchiveFormat`/`supportedArchiveFormats` and `isSingleStreamArchiveFormat`.
  - New `createDecompressStream()` handles `.gz`/`.bz2`/`.zst` (uses Node zstd) in extraction and the download pipeline.
  - New `get-archive-format-from-demo-url()` detects format from the URL pathname (case-insensitive; ignores query/fragment); requests keep query params.
  - Added tests for `.zst` extraction and URL detection (incl. uppercase and signed URLs), non-demo files, existing targets, and corrupted archives cleanup.

<sup>Written for commit 6f3ec421b0f375e604fd28034cf794c2d9915ec7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akiver/cs-demo-manager/pull/1451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

