### PR TITLE
fix(video): map libx264 quality 0 to CRF 1

### DIFF
--- a/src/common/video/get-compatible-constant-rate-factor.test.ts
+++ b/src/common/video/get-compatible-constant-rate-factor.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { getCompatibleConstantRateFactor } from './get-compatible-constant-rate-factor';
+
+describe('getCompatibleConstantRateFactor', () => {
+  it('maps quality 0 to CRF 1 for libx264 so it stays on High profile', () => {
+    expect(getCompatibleConstantRateFactor(0, 'libx264')).toBe(1);
+  });
+
+  it('keeps quality 0 for codecs other than libx264', () => {
+    expect(getCompatibleConstantRateFactor(0, 'libx265')).toBe(0);
+    expect(getCompatibleConstantRateFactor(0, 'h264_nvenc')).toBe(0);
+  });
+
+  it('keeps 1..51 unchanged', () => {
+    expect(getCompatibleConstantRateFactor(1, 'libx264')).toBe(1);
+    expect(getCompatibleConstantRateFactor(23, 'libx264')).toBe(23);
+    expect(getCompatibleConstantRateFactor(51, 'libx264')).toBe(51);
+  });
+});

--- a/src/common/video/get-compatible-constant-rate-factor.ts
+++ b/src/common/video/get-compatible-constant-rate-factor.ts
@@ -1,0 +1,10 @@
+// libx264 CRF 0 is lossless High 4:4:4 Predictive even with yuv420p. AVI /
+// Windows players decode that as heavy blocking. CRF 1 is the lowest value
+// that stays on High profile. Other codecs keep 0.
+export function getCompatibleConstantRateFactor(constantRateFactor: number, videoCodec: string): number {
+  if (constantRateFactor === 0 && videoCodec.trim() === 'libx264') {
+    return 1;
+  }
+
+  return constantRateFactor;
+}

--- a/src/node/video/generation/create-cs2-video-json-file.ts
+++ b/src/node/video/generation/create-cs2-video-json-file.ts
@@ -11,6 +11,7 @@ import { EncoderSoftware } from 'csdm/common/types/encoder-software';
 import type { VideoContainer } from 'csdm/common/types/video-container';
 import type { Camera } from 'csdm/common/types/camera';
 import { lastArrayItem } from 'csdm/common/array/last-array-item';
+import { getCompatibleConstantRateFactor } from 'csdm/common/video/get-compatible-constant-rate-factor';
 
 function getHlaeOutputFolderPath(outputFolderPath: string, sequence: Sequence) {
   return `${windowsToUnixPathSeparator(outputFolderPath)}/${getSequenceName(sequence)}`;
@@ -105,7 +106,7 @@ export async function createCs2VideoJsonFile({
     if (presetName !== 'afxClassic') {
       let presetParameters = `-c:v ${ffmpegSettings.videoCodec} -pix_fmt yuv420p`;
       if (ffmpegSettings.outputParameters === '') {
-        presetParameters += ` -crf ${ffmpegSettings.constantRateFactor}`;
+        presetParameters += ` -crf ${getCompatibleConstantRateFactor(ffmpegSettings.constantRateFactor, ffmpegSettings.videoCodec)}`;
       } else {
         presetParameters += ` ${ffmpegSettings.outputParameters}`;
       }

--- a/src/node/video/generation/create-csgo-video-json-file.ts
+++ b/src/node/video/generation/create-csgo-video-json-file.ts
@@ -9,6 +9,7 @@ import { RecordingOutput } from 'csdm/common/types/recording-output';
 import { EncoderSoftware } from 'csdm/common/types/encoder-software';
 import type { VideoContainer } from 'csdm/common/types/video-container';
 import { lastArrayItem } from 'csdm/common/array/last-array-item';
+import { getCompatibleConstantRateFactor } from 'csdm/common/video/get-compatible-constant-rate-factor';
 
 type Options = {
   type: 'record' | 'watch';
@@ -105,7 +106,7 @@ export async function createCsgoVideoJsonFile({
     if (presetName !== 'afxClassic') {
       let presetParameters = `-c:v ${ffmpegSettings.videoCodec}`;
       if (ffmpegSettings.outputParameters === '') {
-        presetParameters += ` -crf ${ffmpegSettings.constantRateFactor}`;
+        presetParameters += ` -crf ${getCompatibleConstantRateFactor(ffmpegSettings.constantRateFactor, ffmpegSettings.videoCodec)}`;
       } else {
         presetParameters += ` ${ffmpegSettings.outputParameters}`;
       }

--- a/src/node/video/generation/ffmpeg-constant-rate-factor.test.ts
+++ b/src/node/video/generation/ffmpeg-constant-rate-factor.test.ts
@@ -1,0 +1,134 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+import { EncoderSoftware } from 'csdm/common/types/encoder-software';
+import { RecordingOutput } from 'csdm/common/types/recording-output';
+import { RecordingSystem } from 'csdm/common/types/recording-system';
+import type { Sequence } from 'csdm/common/types/sequence';
+import { VideoContainer } from 'csdm/common/types/video-container';
+import { createCs2VideoJsonFile } from './create-cs2-video-json-file';
+import { createCsgoVideoJsonFile } from './create-csgo-video-json-file';
+
+const sequence: Sequence = {
+  number: 1,
+  startTick: 1000,
+  endTick: 2000,
+  showXRay: false,
+  showAssists: true,
+  showOnlyDeathNotices: true,
+  playersOptions: [],
+  playerCameras: [],
+  cameras: [],
+  playerVoicesEnabled: false,
+  recordAudio: false,
+  deathNoticesDuration: 5,
+};
+
+function ffmpegPresetCommand(content: string) {
+  const sequences = JSON.parse(content) as Array<{ actions: Array<{ cmd: string }> }>;
+  const command = sequences
+    .flatMap((item) => item.actions)
+    .find((action) => action.cmd.includes('mirv_streams settings add ffmpeg'))?.cmd;
+
+  expect(command).toBeDefined();
+  return command as string;
+}
+
+async function withDemoJson(run: (demoPath: string) => Promise<void>) {
+  const folderPath = await fs.mkdtemp(path.join(os.tmpdir(), 'csdm-crf-'));
+  try {
+    await run(path.join(folderPath, 'demo.dem'));
+  } finally {
+    await fs.rm(folderPath, { recursive: true, force: true });
+  }
+}
+
+describe('FFmpeg quality 0 in HLAE presets', () => {
+  it('emits CRF 1 for libx264 quality 0 on the CS2 FFmpeg preset', async () => {
+    await withDemoJson(async (demoPath) => {
+      await createCs2VideoJsonFile({
+        type: 'record',
+        recordingSystem: RecordingSystem.HLAE,
+        recordingOutput: RecordingOutput.Video,
+        encoderSoftware: EncoderSoftware.FFmpeg,
+        outputFolderPath: path.dirname(demoPath),
+        framerate: 30,
+        demoPath,
+        sequences: [sequence],
+        closeGameAfterRecording: true,
+        trueView: false,
+        tickrate: 64,
+        players: [],
+        cameras: [],
+        ffmpegSettings: {
+          constantRateFactor: 0,
+          videoContainer: VideoContainer.AVI,
+          videoCodec: 'libx264',
+          outputParameters: '',
+        },
+      });
+
+      const command = ffmpegPresetCommand(await fs.readFile(`${demoPath}.json`, 'utf8'));
+      expect(command).toContain('-crf 1');
+      expect(command).not.toContain('-crf 0');
+    });
+  });
+
+  it('emits CRF 0 for libx265 quality 0 on the CS2 FFmpeg preset', async () => {
+    await withDemoJson(async (demoPath) => {
+      await createCs2VideoJsonFile({
+        type: 'record',
+        recordingSystem: RecordingSystem.HLAE,
+        recordingOutput: RecordingOutput.Video,
+        encoderSoftware: EncoderSoftware.FFmpeg,
+        outputFolderPath: path.dirname(demoPath),
+        framerate: 30,
+        demoPath,
+        sequences: [sequence],
+        closeGameAfterRecording: true,
+        trueView: false,
+        tickrate: 64,
+        players: [],
+        cameras: [],
+        ffmpegSettings: {
+          constantRateFactor: 0,
+          videoContainer: VideoContainer.AVI,
+          videoCodec: 'libx265',
+          outputParameters: '',
+        },
+      });
+
+      const command = ffmpegPresetCommand(await fs.readFile(`${demoPath}.json`, 'utf8'));
+      expect(command).toContain('-c:v libx265');
+      expect(command).toContain('-crf 0');
+    });
+  });
+
+  it('emits CRF 1 for libx264 quality 0 on the CS:GO FFmpeg preset', async () => {
+    await withDemoJson(async (demoPath) => {
+      await createCsgoVideoJsonFile({
+        type: 'record',
+        recordingSystem: RecordingSystem.HLAE,
+        recordingOutput: RecordingOutput.Video,
+        encoderSoftware: EncoderSoftware.FFmpeg,
+        outputFolderPath: path.dirname(demoPath),
+        framerate: 30,
+        demoPath,
+        sequences: [sequence],
+        closeGameAfterRecording: true,
+        tickrate: 64,
+        ffmpegSettings: {
+          constantRateFactor: 0,
+          videoContainer: VideoContainer.AVI,
+          videoCodec: 'libx264',
+          outputParameters: '',
+        },
+      });
+
+      const command = ffmpegPresetCommand(await fs.readFile(`${demoPath}.json`, 'utf8'));
+      expect(command).toContain('-crf 1');
+      expect(command).not.toContain('-crf 0');
+    });
+  });
+});

--- a/src/node/video/generation/generate-video-with-ffmpeg.ts
+++ b/src/node/video/generation/generate-video-with-ffmpeg.ts
@@ -10,6 +10,7 @@ import { executeFfmpeg } from 'csdm/node/video/ffmpeg/execute-ffmpeg';
 import type { VideoContainer } from 'csdm/common/types/video-container';
 import { RecordingOutput } from 'csdm/common/types/recording-output';
 import { RecordingSystem } from 'csdm/common/types/recording-system';
+import { getCompatibleConstantRateFactor } from 'csdm/common/video/get-compatible-constant-rate-factor';
 import { RawFilesNotFoundError } from '../errors/raw-files-not-found';
 
 async function convertGameAudioFile(
@@ -181,7 +182,7 @@ export async function generateVideoWithFFmpeg(settings: GenerateVideoWithFFmpegS
   if (outputParameters !== '') {
     args.push(outputParameters);
   } else {
-    args.push(`-pix_fmt yuv420p`, `-crf ${constantRateFactor}`);
+    args.push(`-pix_fmt yuv420p`, `-crf ${getCompatibleConstantRateFactor(constantRateFactor, videoCodec)}`);
   }
 
   args.push(`"${outputPath}"`);


### PR DESCRIPTION
Quality 0 with the default libx264 + AVI path currently looks way worse than 1. FFmpeg treats `-crf 0` as lossless High 4:4:4 Predictive even with `-pix_fmt yuv420p`, and a lot of AVI/Windows players decode that as heavy blocking.

I remap libx264 quality 0 to CRF 1 when we emit `-crf` (FFmpeg encode and the HLAE CS2/CSGO presets). CRF 1 stays on High profile. Other codecs still get 0, and custom output parameters are left alone.

Fixes #1455

## Verification
- before, on current `main`: Quality 0 + libx264 + empty output params emits `-crf 0`. FFmpeg 8.1.2 encodes that as High 4:4:4 Predictive.
- after: same path emits `-crf 1` for libx264. libx265 quality 0 still emits `-crf 0`.
- `vp run test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Map `libx264` quality 0 to CRF 1 when emitting `-crf`, preventing AVI/Windows playback artifacts. Previously quality 0 emitted `-crf 0` (lossless High 4:4:4 Predictive even with `yuv420p`); now we emit `-crf 1` to stay on High profile.

- Applied in the FFmpeg encode path and HLAE CS2/CS:GO presets via `getCompatibleConstantRateFactor`.
- Only affects `libx264` with empty `outputParameters`; other codecs (e.g., `libx265`, `h264_nvenc`) still use 0, and explicit `outputParameters` are unchanged.
- Added tests for the mapping and preset commands (`-crf 1` for `libx264`, `-crf 0` for `libx265`).
- If you need true lossless `libx264`, set `outputParameters` to include `-crf 0` explicitly.

<sup>Written for commit a0846fb02e11426b3d4dc02d3ca2ca7adcd71292. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akiver/cs-demo-manager/pull/1456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

