### PR TITLE
fix(video): warn about lossless libx264 output

### DIFF
--- a/src/ui/match/video/ffmpeg/constant-rate-factor-input.tsx
+++ b/src/ui/match/video/ffmpeg/constant-rate-factor-input.tsx
@@ -76,7 +76,7 @@ export function ConstantRateFactorInput() {
       />
       {displaysLosslessCompatibilityWarning && (
         <div className="flex items-center gap-x-4">
-          <ExclamationTriangleIcon className="size-12 shrink-0 text-orange-700" />
+          <ExclamationTriangleIcon aria-hidden="true" className="size-12 shrink-0 text-orange-700" />
           <p className="text-caption">
             <Trans>Quality 0 with libx264 creates a lossless video that some players can't decode.</Trans>
           </p>

--- a/src/ui/match/video/ffmpeg/constant-rate-factor-input.tsx
+++ b/src/ui/match/video/ffmpeg/constant-rate-factor-input.tsx
@@ -5,6 +5,7 @@ import { InputLabel } from 'csdm/ui/components/inputs/input-label';
 import { useVideoSettings } from 'csdm/ui/settings/video/use-video-settings';
 import { defaultSettings } from 'csdm/node/settings/default-settings';
 import { EncoderSoftware } from 'csdm/common/types/encoder-software';
+import { ExclamationTriangleIcon } from 'csdm/ui/icons/exclamation-triangle-icon';
 
 export function ConstantRateFactorInput() {
   const id = useId();
@@ -15,6 +16,8 @@ export function ConstantRateFactorInput() {
   // The -crf option is not passed to FFmpeg when custom output parameters are defined (users have full control)
   const isDisabled =
     settings.encoderSoftware === EncoderSoftware.FFmpeg && settings.ffmpegSettings.outputParameters !== '';
+  const displaysLosslessCompatibilityWarning =
+    !isDisabled && settings.ffmpegSettings.constantRateFactor === 0 && settings.ffmpegSettings.videoCodec === 'libx264';
 
   const onBlur = async (event: React.FocusEvent<HTMLInputElement>) => {
     const value = event.target.value.trim();
@@ -71,6 +74,14 @@ export function ConstantRateFactorInput() {
         placeholder={String(defaultValue)}
         isDisabled={isDisabled}
       />
+      {displaysLosslessCompatibilityWarning && (
+        <div className="flex items-center gap-x-4">
+          <ExclamationTriangleIcon className="size-12 shrink-0 text-orange-700" />
+          <p className="text-caption">
+            <Trans>Quality 0 with libx264 creates a lossless video that some players can't decode.</Trans>
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/ui/translations/en/messages.po
+++ b/src/ui/translations/en/messages.po
@@ -5058,6 +5058,10 @@ msgctxt "Input label"
 msgid "Quality"
 msgstr "Quality"
 
+#: src/ui/match/video/ffmpeg/constant-rate-factor-input.tsx
+msgid "Quality 0 with libx264 creates a lossless video that some players can't decode."
+msgstr "Quality 0 with libx264 creates a lossless video that some players can't decode."
+
 #: src/ui/match/video/ffmpeg/ffmpeg-audio-bitrate-select.tsx
 msgctxt "Input label"
 msgid "Audio bitrate"


### PR DESCRIPTION
## Why

`libx264` quality 0 produces lossless output that some video players can't decode. Silently changing 0 to another value would make the UI differ from the command that runs and remove the existing lossless option.

This keeps CRF 0 unchanged and shows a warning beside the quality field only when `libx264` and the built-in FFmpeg parameters are active.

## Verification

- `vp check`
- `vp run test` (51 passed)
- `vp run deadcode`
- `vp run i18n:extract`
- rendered the component for CRF 0/1, `libx264`/`libx265`, and custom-output states

Follow-up to #1456 and #1455.
