### PR TITLE
fix(video): duplicated word in highlight kills tooltip #1464

### DIFF
--- a/src/ui/match/video/sequence/sequence-players.tsx
+++ b/src/ui/match/video/sequence/sequence-players.tsx
@@ -71,7 +71,7 @@ export function SequencePlayers() {
         }),
         headerTooltip: t({
           context: 'Table header tooltip',
-          message: 'Highlight kills kills',
+          message: 'Highlight kills',
         }),
         width: 40,
         Cell: HighlightPlayerKillsCheckbox,

--- a/src/ui/translations/en/messages.po
+++ b/src/ui/translations/en/messages.po
@@ -5730,9 +5730,10 @@ msgid "H"
 msgstr "H"
 
 #: src/ui/match/video/sequence/sequence-players.tsx
+#: src/ui/match/video/sequences/edit-sequences/player-options/sequence-players-options.tsx
 msgctxt "Table header tooltip"
-msgid "Highlight kills kills"
-msgstr "Highlight kills kills"
+msgid "Highlight kills"
+msgstr "Highlight kills"
 
 #: src/ui/match/video/sequence/sequence-players.tsx
 #: src/ui/match/video/sequences/edit-sequences/player-options/sequence-players-options.tsx
@@ -5803,11 +5804,6 @@ msgstr "Override CFG"
 #: src/ui/match/video/sequences/edit-sequences/edit-sequences-settings-dialog.tsx
 msgid "Override player options"
 msgstr "Override player options"
-
-#: src/ui/match/video/sequences/edit-sequences/player-options/sequence-players-options.tsx
-msgctxt "Table header tooltip"
-msgid "Highlight kills"
-msgstr "Highlight kills"
 
 #: src/ui/match/video/sequences/required-disk-space.tsx
 msgctxt "Disk usage in megabyte"


### PR DESCRIPTION
Fixes #1464

The tooltip for the "highlight kills" column read "Highlight kills kills", the word "kills" was duplicated.

Since this string is extracted for translation, the typo was also propagated to Crowdin and to every localized build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "highlight kills" column tooltip so it no longer reads "Highlight kills kills".

The typo was also fixed in the English translation source, which means Crowdin and localized builds will pick up the corrected string. The translation entries for the tooltip were merged since both source files now share the same message.

<sup>Written for commit caa1f9342044a0c607d81582e081bc081cf3f723. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akiver/cs-demo-manager/pull/1465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

