### PR TITLE
[TEST] feat: pglite as database backend

### DIFF
--- a/electron-builder.config.mjs
+++ b/electron-builder.config.mjs
@@ -132,6 +132,8 @@ const config = {
       to: '.',
     },
   ],
+  // PGlite loads its WASM/data files from the filesystem at runtime, keep them outside the asar archive.
+  asarUnpack: ['node_modules/@electric-sql/pglite/**'],
   beforePack: async (context) => {
     const { installBoilerWritter, installCounterStrikeVoiceExtractor, installDemoAnalyzer } =
       await import('./scripts/install-deps.mjs');

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@date-fns/tz": "1.5.0",
     "@daypicker/react": "10.0.1",
     "@e18e/eslint-plugin": "0.5.1",
+    "@electric-sql/pglite": "0.5.8",
     "@fast-csv/parse": "5.0.7",
     "@floating-ui/react": "0.27.20",
     "@lingui/babel-plugin-lingui-macro": "6.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       '@e18e/eslint-plugin':
         specifier: 0.5.1
         version: 0.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(oxlint@1.73.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.5(@types/node@24.13.3)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0)))
+      '@electric-sql/pglite':
+        specifier: 0.5.8
+        version: 0.5.8
       '@fast-csv/parse':
         specifier: 5.0.7
         version: 5.0.7
@@ -552,6 +555,9 @@ packages:
         optional: true
       oxlint:
         optional: true
+
+  '@electric-sql/pglite@0.5.8':
+    resolution: {integrity: sha512-n9tsbUOhwx2epK1V0ZG9Ar4SHWUju04dhmzZXiSBXwBoleOvIfals33NAaWgagQVAL4Rbvx/Ptsu3P+pA09f6Q==}
 
   '@electron-internal/extract-zip@1.0.3':
     resolution: {integrity: sha512-OjKpjB7gohtEjZiq6nDx1egqjZJhGPN1iFOIED+NFhB/MMkXw/XRcHjh1DGXKT5z2W9eW7Jy2UKU3gpjvusFTQ==}
@@ -6166,6 +6172,8 @@ snapshots:
     optionalDependencies:
       eslint: 10.7.0(jiti@2.7.0)(supports-color@7.2.0)
       oxlint: 1.73.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.5(@types/node@24.13.3)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(typescript@7.0.2)(yaml@2.9.0))
+
+  '@electric-sql/pglite@0.5.8': {}
 
   '@electron-internal/extract-zip@1.0.3': {}
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -115,6 +115,7 @@ async function buildWebSocketServerBundle() {
       external: [
         'pg-native',
         '@aws-sdk/client-s3', // the unzipper module has it as a dev dependency
+        '@electric-sql/pglite', // loads its WASM/data files from the package folder, shipped as a real node_modules package
       ],
       define: {
         'process.env.STEAM_API_KEYS': `"${process.env.STEAM_API_KEYS}"`,
@@ -122,6 +123,36 @@ async function buildWebSocketServerBundle() {
       },
     }),
   );
+}
+
+// PGlite is not bundled by rolldown because at runtime it loads its WASM/data files from the package folder.
+// The package is copied into the out folder so the server and CLI bundles can resolve it in production.
+async function copyPgliteAssets() {
+  const packageFolderPath = path.join(rootFolderPath, 'node_modules', '@electric-sql', 'pglite');
+  const outputFolderPath = path.join(outFolderPath, 'node_modules', '@electric-sql', 'pglite');
+  // Source maps, TypeScript declarations and Postgres extension tarballs (extensions are not used) are not needed
+  // at runtime.
+  const excludedExtensions = ['.map', '.d.ts', '.d.cts', '.tar.gz'];
+  await fs.copy(packageFolderPath, outputFolderPath, {
+    filter: (src) => {
+      return !excludedExtensions.some((extension) => src.endsWith(extension));
+    },
+  });
+}
+
+// PGlite is not bundled because at runtime it loads its WASM/data files from the package folder.
+// The package is copied into the out folder so the server and CLI bundles can resolve it in production.
+async function copyPgliteAssets() {
+  const packageFolderPath = path.join(rootFolderPath, 'node_modules', '@electric-sql', 'pglite');
+  const outputFolderPath = path.join(outFolderPath, 'node_modules', '@electric-sql', 'pglite');
+  // Source maps, TypeScript declarations and Postgres extension tarballs (extensions are not used) are not needed
+  // at runtime.
+  const excludedExtensions = ['.map', '.d.ts', '.d.cts', '.tar.gz'];
+  await fs.copy(packageFolderPath, outputFolderPath, {
+    filter: (src) => {
+      return !excludedExtensions.some((extension) => src.endsWith(extension));
+    },
+  });
 }
 
 async function buildMainProcessBundle() {
@@ -158,7 +189,7 @@ async function buildCliBundle() {
     createNodeBundleOptions({
       entryPoint: 'cli/cli.ts',
       outputFileName: 'cli.js',
-      external: ['pg-native', '@aws-sdk/client-s3'],
+      external: ['pg-native', '@aws-sdk/client-s3', '@electric-sql/pglite'],
       define: {
         'process.env.STEAM_API_KEYS': `"${process.env.STEAM_API_KEYS}"`,
         'process.env.FACEIT_API_KEY': `"${process.env.FACEIT_API_KEY}"`,
@@ -170,7 +201,13 @@ async function buildCliBundle() {
 try {
   downloadTranslations();
   await buildRendererProcessBundle();
-  await Promise.all([buildWebSocketServerBundle(), buildMainProcessBundle(), buildPreloadBundle(), buildCliBundle()]);
+  await Promise.all([
+    buildWebSocketServerBundle(),
+    buildMainProcessBundle(),
+    buildPreloadBundle(),
+    buildCliBundle(),
+    copyPgliteAssets(),
+  ]);
 } catch (error) {
   console.error(error);
   process.exit(1);

--- a/scripts/develop-cli.mjs
+++ b/scripts/develop-cli.mjs
@@ -29,6 +29,7 @@ const commonOptions = {
   external: [
     'pg-native',
     '@aws-sdk/client-s3', // the unzipper module has it as a dev dependency
+    '@electric-sql/pglite', // loads its WASM/data files from the package folder, resolved from node_modules in dev
   ],
   plugins: [nativeNodeModulesPlugin],
 };

--- a/scripts/develop.mjs
+++ b/scripts/develop.mjs
@@ -147,6 +147,7 @@ async function buildAndWatchMainProcessBundles() {
     external: [
       'pg-native',
       '@aws-sdk/client-s3', // the unzipper module has it as a dev dependency
+      '@electric-sql/pglite', // loads its WASM/data files from the package folder, resolved from node_modules in dev
     ],
     transform: {
       target: `node${node}`,

--- a/src/cli/commands/command.ts
+++ b/src/cli/commands/command.ts
@@ -4,6 +4,7 @@ import { createDatabaseConnection } from 'csdm/node/database/database';
 import { migrateDatabase } from 'csdm/node/database/migrations/migrate-database';
 import { createDaemonConnection } from 'csdm/cli/create-daemon-connection';
 import type { CliWebSocketClient } from 'csdm/cli/web-socket/cli-web-socket-client';
+import { EmbeddedDatabaseLocked } from 'csdm/node/database/pglite/errors/embedded-database-locked';
 
 export abstract class Command {
   public abstract getDescription(): string;
@@ -35,7 +36,17 @@ export abstract class Command {
 
   protected async initDatabaseConnection() {
     const settings = await getSettings();
-    createDatabaseConnection(settings.database);
+    try {
+      await createDatabaseConnection(settings.database);
+    } catch (error) {
+      if (error instanceof EmbeddedDatabaseLocked) {
+        console.error(
+          'The embedded database is already in use, probably by the CS Demo Manager app. Close it and try again.',
+        );
+        this.exitWithFailure();
+      }
+      throw error;
+    }
     await migrateDatabase();
   }
 

--- a/src/cli/get-error-code-message.ts
+++ b/src/cli/get-error-code-message.ts
@@ -27,6 +27,8 @@ export function getErrorCodeMessage(errorCode: ErrorCode): string {
       return 'Error while inserting the match rounds into the database.';
     case ErrorCode.DatabaseSchemaVersionMismatch:
       return 'The database schema is outdated, start the GUI to run the migrations.';
+    case ErrorCode.EmbeddedDatabaseLocked:
+      return 'The embedded database is already in use, probably by the CS Demo Manager app. Close it and try again.';
     case ErrorCode.StartCounterStrikeError:
       return 'Failed to start the game, make sure Steam is running and you are connected.';
     case ErrorCode.CounterStrikeExecutableNotFound:

--- a/src/common/error-code.ts
+++ b/src/common/error-code.ts
@@ -36,6 +36,7 @@ export const ErrorCode = {
   DuplicateTeamName: 507,
   MapAlreadyExists: 600,
   DatabaseSchemaVersionMismatch: 701,
+  EmbeddedDatabaseLocked: 702,
   BoilerInvalidArgs: 800,
   BoilerCommunicationFailure: 801,
   BoilerAlreadyConnected: 802,

--- a/src/common/types/database-mode.ts
+++ b/src/common/types/database-mode.ts
@@ -1,0 +1,6 @@
+export const DatabaseMode = {
+  Embedded: 'embedded',
+  PostgreSql: 'postgresql',
+} as const;
+
+export type DatabaseMode = (typeof DatabaseMode)[keyof typeof DatabaseMode];

--- a/src/node/database/cameras/insert-cameras.ts
+++ b/src/node/database/cameras/insert-cameras.ts
@@ -1,6 +1,6 @@
 import { db } from 'csdm/node/database/database';
 import type { InsertableCamera } from './cameras-table';
-import { DatabaseError } from 'pg';
+import { getDatabaseErrorCode } from 'csdm/node/database/get-database-error-code';
 import { PostgresqlErrorCode } from '../postgresql-error-code';
 import { CameraAlreadyExists } from './errors/camera-already-exists';
 
@@ -14,11 +14,8 @@ export async function insertCamera(camera: InsertableCamera) {
 
     return rows[0];
   } catch (error) {
-    if (error instanceof DatabaseError) {
-      switch (error.code) {
-        case PostgresqlErrorCode.UniqueViolation:
-          throw new CameraAlreadyExists();
-      }
+    if (getDatabaseErrorCode(error) === PostgresqlErrorCode.UniqueViolation) {
+      throw new CameraAlreadyExists();
     }
 
     throw error;

--- a/src/node/database/connect-database.ts
+++ b/src/node/database/connect-database.ts
@@ -3,6 +3,7 @@ import type { DatabaseSettings } from 'csdm/node/settings/settings';
 import { getSettings } from 'csdm/node/settings/get-settings';
 import { migrateDatabase } from 'csdm/node/database/migrations/migrate-database';
 import { createDatabaseIfNotExists } from 'csdm/node/database/create-database-if-not-exists';
+import { DatabaseMode } from 'csdm/common/types/database-mode';
 import { startBackgroundTasks } from 'csdm/server/start-background-tasks';
 
 export async function connectDatabase(databaseSettings?: DatabaseSettings) {
@@ -11,8 +12,13 @@ export async function connectDatabase(databaseSettings?: DatabaseSettings) {
     databaseSettings = settings.database;
   }
 
-  await createDatabaseIfNotExists(databaseSettings);
-  createDatabaseConnection(databaseSettings);
+  // The embedded database is bundled with the app, only the "postgresql" mode requires a PostgreSQL server on
+  // the host machine.
+  if (databaseSettings.mode === DatabaseMode.PostgreSql) {
+    await createDatabaseIfNotExists(databaseSettings);
+  }
+
+  await createDatabaseConnection(databaseSettings);
   await migrateDatabase();
   void startBackgroundTasks();
 }

--- a/src/node/database/copy-csv-into-table.ts
+++ b/src/node/database/copy-csv-into-table.ts
@@ -1,7 +1,9 @@
 import { createReadStream } from 'node:fs';
 import { pipeline } from 'node:stream/promises';
+import fs from 'fs-extra';
 import { from as copyFrom } from 'pg-copy-streams';
-import { acquireIngestionClient, releaseIngestionClient } from './database';
+import { acquireIngestionClient, isEmbeddedDatabase, releaseIngestionClient } from './database';
+import { getPgliteInstance } from './pglite/pglite-instance';
 import type { Database } from './schema';
 
 type Options<Table> = {
@@ -15,12 +17,21 @@ type Options<Table> = {
 // are forwarded as-is to the server, there is no parsing on the JS side.
 export async function copyCsvIntoTable<Table>({ csvFilePath, tableName, columns }: Options<Table>) {
   const columnNames = columns.map((column) => `"${String(column)}"`).join(',');
+  const copyOptions = "WITH (FORMAT csv, DELIMITER ',', ENCODING 'UTF8')";
+
+  if (isEmbeddedDatabase()) {
+    // PGlite doesn't support COPY FROM STDIN, the file content is passed as a blob instead.
+    const csv = await fs.readFile(csvFilePath);
+    await getPgliteInstance().query(`COPY "${tableName}"(${columnNames}) FROM '/dev/blob' ${copyOptions}`, [], {
+      blob: new Blob([csv]),
+    });
+    return;
+  }
+
   const client = await acquireIngestionClient();
 
   try {
-    const stream = client.query(
-      copyFrom(`COPY "${tableName}"(${columnNames}) FROM STDIN WITH (FORMAT csv, DELIMITER ',', ENCODING 'UTF8')`),
-    );
+    const stream = client.query(copyFrom(`COPY "${tableName}"(${columnNames}) FROM STDIN ${copyOptions}`));
     // On error the pipeline destroys the stream, which sends a CopyFail to the backend.
     await pipeline(createReadStream(csvFilePath), stream);
   } finally {

--- a/src/node/database/database.ts
+++ b/src/node/database/database.ts
@@ -1,11 +1,16 @@
 import { types, Pool, type PoolClient } from 'pg';
-import type { KyselyConfig, LogEvent, Logger } from 'kysely';
+import type { Dialect, KyselyConfig, LogEvent, Logger } from 'kysely';
 import { Kysely, PostgresDialect } from 'kysely';
 import type { DatabaseSettings } from 'csdm/node/settings/settings';
+import { DatabaseMode } from 'csdm/common/types/database-mode';
+import { PGliteDialect } from './pglite/pglite-dialect';
+import { createPgliteInstance } from './pglite/pglite-instance';
 import type { Database } from './schema';
 
 export let db: Kysely<Database>;
 
+// Mode of the current connection, undefined while disconnected.
+let databaseMode: DatabaseMode | undefined;
 let ingestionPool: Pool | undefined;
 const ingestionClients = new Set<PoolClient>();
 const pendingAcquisitions = new Set<(error: Error) => void>();
@@ -32,17 +37,22 @@ types.setTypeParser(types.builtins.NUMERIC, Number);
 types.setTypeParser(types.builtins.INT4, Number);
 types.setTypeParser(types.builtins.INT2, Number);
 
-export function createDatabaseConnection(settings: DatabaseSettings) {
-  const dialect = new PostgresDialect({
-    pool: new Pool({
-      host: settings.hostname,
-      port: settings.port,
-      user: settings.username,
-      password: settings.password,
-      database: settings.database,
-      connectionTimeoutMillis: 10000,
-    }),
-  });
+export async function createDatabaseConnection(settings: DatabaseSettings) {
+  let dialect: Dialect;
+  if (settings.mode === DatabaseMode.Embedded) {
+    dialect = new PGliteDialect(await createPgliteInstance());
+  } else {
+    dialect = new PostgresDialect({
+      pool: new Pool({
+        host: settings.hostname,
+        port: settings.port,
+        user: settings.username,
+        password: settings.password,
+        database: settings.database,
+        connectionTimeoutMillis: 10000,
+      }),
+    });
+  }
 
   let loggerFunction: Logger;
   if (process.env.LOG_DATABASE_QUERIES) {
@@ -77,33 +87,40 @@ export function createDatabaseConnection(settings: DatabaseSettings) {
     logger.error(error);
   });
 
-  // Dedicated pool for data ingestion.
-  // It's separated from the Kysely pool because an ingestion may send dozens of concurrent COPY
-  // commands and each of them holds its connection until the whole CSV file has been streamed.
-  // Sharing the Kysely pool would starve the app queries and, worse, the queued acquisitions would
-  // be rejected by its connectionTimeoutMillis, which also applies to the time spent waiting in the
-  // pool queue.
-  // Created eagerly (it opens connections only on first use) so its existence tracks the connection
-  // state.
-  ingestionPool = new Pool({
-    host: settings.hostname,
-    port: settings.port,
-    user: settings.username,
-    password: settings.password,
-    database: settings.database,
-    max: 8,
-    // COPY commands may take minutes, waiting for a free connection must not time out.
-    connectionTimeoutMillis: 0,
-    // Ingestion may write hundreds of thousands of rows that can be re-generated from their
-    // source, waiting for the WAL to be flushed on each commit is not worth the cost.
-    // Set on the pool rather than per COPY: it's a session setting, it would be redundant.
-    options: '-c synchronous_commit=off',
-  });
+  if (settings.mode === DatabaseMode.PostgreSql) {
+    // Dedicated pool for data ingestion.
+    // It's separated from the Kysely pool because an ingestion may send dozens of concurrent COPY
+    // commands and each of them holds its connection until the whole CSV file has been streamed.
+    // Sharing the Kysely pool would starve the app queries and, worse, the queued acquisitions would
+    // be rejected by its connectionTimeoutMillis, which also applies to the time spent waiting in the
+    // pool queue.
+    // The embedded database has a single connection, its COPY goes through the PGlite instance
+    // directly (see copy-csv-into-table.ts).
+    ingestionPool = new Pool({
+      host: settings.hostname,
+      port: settings.port,
+      user: settings.username,
+      password: settings.password,
+      database: settings.database,
+      max: 8,
+      // COPY commands may take minutes, waiting for a free connection must not time out.
+      connectionTimeoutMillis: 0,
+      // Ingestion may write hundreds of thousands of rows that can be re-generated from their
+      // source, waiting for the WAL to be flushed on each commit is not worth the cost.
+      // Set on the pool rather than per COPY: it's a session setting, it would be redundant.
+      options: '-c synchronous_commit=off',
+    });
+  }
   db = new Kysely<Database>(config);
+  databaseMode = settings.mode;
 }
 
 export function isDatabaseConnected() {
-  return ingestionPool !== undefined;
+  return databaseMode !== undefined;
+}
+
+export function isEmbeddedDatabase() {
+  return databaseMode === DatabaseMode.Embedded;
 }
 
 function getIngestionPool(): Pool {
@@ -190,5 +207,7 @@ export function releaseIngestionClient(client: PoolClient) {
 }
 
 export async function destroyDatabaseConnection() {
+  databaseMode = undefined;
+  // Destroying the Kysely instance closes the PGlite instance in embedded mode.
   await Promise.all([db?.destroy(), discardIngestionPool()]);
 }

--- a/src/node/database/faceit-matches/insert-faceit-match.ts
+++ b/src/node/database/faceit-matches/insert-faceit-match.ts
@@ -1,6 +1,6 @@
-import { DatabaseError } from 'pg';
 import type { FaceitMatch } from 'csdm/common/types/faceit-match';
 import { db } from 'csdm/node/database/database';
+import { getDatabaseErrorCode } from 'csdm/node/database/get-database-error-code';
 import { PostgresqlErrorCode } from '../postgresql-error-code';
 import type { InsertableFaceitMatchPlayer } from './faceit-match-player-table';
 import type { InsertableFaceitMatchTeam } from './faceit-match-team-table';
@@ -66,11 +66,8 @@ export async function insertFaceitMatch(match: FaceitMatch) {
       await transaction.insertInto('faceit_match_teams').values(buildTeamRows(match)).execute();
       await transaction.insertInto('faceit_match_players').values(buildPlayerRows(match)).execute();
     } catch (error) {
-      if (error instanceof DatabaseError) {
-        switch (error.code) {
-          case PostgresqlErrorCode.UniqueViolation:
-            return;
-        }
+      if (getDatabaseErrorCode(error) === PostgresqlErrorCode.UniqueViolation) {
+        return;
       }
       throw error;
     }

--- a/src/node/database/get-database-error-code.ts
+++ b/src/node/database/get-database-error-code.ts
@@ -1,0 +1,12 @@
+import { DatabaseError } from 'pg';
+import { messages } from '@electric-sql/pglite';
+
+// node-pg (PostgreSQL mode) and PGlite (embedded mode) both throw their own DatabaseError class exposing the
+// SQLSTATE error code in a `code` property.
+export function getDatabaseErrorCode(error: unknown) {
+  if (error instanceof DatabaseError || error instanceof messages.DatabaseError) {
+    return error.code;
+  }
+
+  return undefined;
+}

--- a/src/node/database/maps/insert-maps.ts
+++ b/src/node/database/maps/insert-maps.ts
@@ -1,5 +1,5 @@
-import { DatabaseError } from 'pg';
 import { db } from 'csdm/node/database/database';
+import { getDatabaseErrorCode } from 'csdm/node/database/get-database-error-code';
 import { PostgresqlErrorCode } from '../postgresql-error-code';
 import { MapAlreadyExists } from './errors/map-already-exists';
 import type { InsertableMap } from './map-table';
@@ -10,11 +10,8 @@ export async function insertMaps(maps: InsertableMap[]) {
 
     return insertedMaps;
   } catch (error) {
-    if (error instanceof DatabaseError) {
-      switch (error.code) {
-        case PostgresqlErrorCode.UniqueViolation:
-          throw new MapAlreadyExists();
-      }
+    if (getDatabaseErrorCode(error) === PostgresqlErrorCode.UniqueViolation) {
+      throw new MapAlreadyExists();
     }
 
     throw error;

--- a/src/node/database/migrations/migrate-database.ts
+++ b/src/node/database/migrations/migrate-database.ts
@@ -1,6 +1,6 @@
-import { DatabaseError } from 'pg';
 import { sql } from 'kysely';
 import { db } from 'csdm/node/database/database';
+import { getDatabaseErrorCode } from 'csdm/node/database/get-database-error-code';
 import { ensureMigrationsTableExists } from 'csdm/node/database/migrations/ensure-migrations-table-exists';
 import { resetDatabase } from '../reset-database';
 import { PostgresqlErrorCode } from '../postgresql-error-code';
@@ -30,7 +30,7 @@ async function getCurrentSchemaVersion() {
 
     return migrationRow?.schemaVersion ?? 0;
   } catch (error) {
-    if (error instanceof DatabaseError && error.code === PostgresqlErrorCode.UndefinedTable) {
+    if (getDatabaseErrorCode(error) === PostgresqlErrorCode.UndefinedTable) {
       return 0;
     }
 

--- a/src/node/database/pglite/errors/embedded-database-locked.ts
+++ b/src/node/database/pglite/errors/embedded-database-locked.ts
@@ -1,0 +1,9 @@
+import { BaseError } from 'csdm/node/errors/base-error';
+import { ErrorCode } from 'csdm/common/error-code';
+
+export class EmbeddedDatabaseLocked extends BaseError {
+  public constructor(lockedByPid: number) {
+    super(ErrorCode.EmbeddedDatabaseLocked);
+    this.message = `The embedded database is already in use by the process with PID ${lockedByPid}`;
+  }
+}

--- a/src/node/database/pglite/pglite-dialect.test.ts
+++ b/src/node/database/pglite/pglite-dialect.test.ts
@@ -1,0 +1,264 @@
+// Validates the embedded database backend (PGlite) against the parts of the app that are sensitive to the
+// PostgreSQL server → PGlite switch:
+// - all schema migrations (PL/pgSQL triggers, stored generated columns, views)
+// - bulk inserts via COPY FROM '/dev/blob' as a replacement for the psql \copy command
+// - int8/numeric type parsing parity with the node-pg type parsers configured in database.ts
+// - SQLSTATE error codes exposure (unique violation, undefined table)
+// - maintenance queries used by the app (VACUUM FULL, pg_database_size)
+import { PGlite, types } from '@electric-sql/pglite';
+import { Kysely, sql } from 'kysely';
+import { describe, expect, it } from 'vite-plus/test';
+import type { Database } from 'csdm/node/database/schema';
+import { ensureMigrationsTableExists } from 'csdm/node/database/migrations/ensure-migrations-table-exists';
+import { getAllMigrations } from 'csdm/node/database/migrations/get-all-migrations';
+import { getDatabaseErrorCode } from 'csdm/node/database/get-database-error-code';
+import { PostgresqlErrorCode } from 'csdm/node/database/postgresql-error-code';
+import { EconomyBan } from 'csdm/node/steam-web-api/steam-constants';
+import { PGliteDialect } from './pglite-dialect';
+
+type TestContext = {
+  pglite: PGlite;
+  db: Kysely<Database>;
+};
+
+let contextPromise: Promise<TestContext> | undefined;
+
+async function createContext(): Promise<TestContext> {
+  // In-memory instance with the same parsers as createPgliteInstance() to keep tests fast and isolated.
+  const pglite = await PGlite.create({
+    parsers: {
+      [types.INT8]: (value: string) => {
+        const valueAsNumber = Number(value);
+        if (Number.isSafeInteger(valueAsNumber)) {
+          return valueAsNumber;
+        }
+
+        return value;
+      },
+      [types.NUMERIC]: Number,
+      [types.INT4]: Number,
+      [types.INT2]: Number,
+    },
+  });
+
+  const db = new Kysely<Database>({
+    dialect: new PGliteDialect(pglite),
+  });
+
+  // Mirrors migrateDatabase() from a fresh installation state (schema version 0, no reset needed).
+  await db.transaction().execute(async (transaction) => {
+    await ensureMigrationsTableExists(transaction);
+    const migrations = await getAllMigrations();
+    for (const migration of migrations) {
+      await migration.run(transaction);
+    }
+
+    await transaction
+      .insertInto('migrations')
+      .values({
+        schema_version: 14, // CURRENT_SCHEMA_VERSION in migrate-database.ts, not exported.
+        run_at: sql`now()`,
+      })
+      .execute();
+  });
+
+  return { pglite, db };
+}
+
+function getContext(): Promise<TestContext> {
+  contextPromise ??= createContext();
+
+  return contextPromise;
+}
+
+const matchChecksum = 'pglite-spike-checksum';
+
+async function insertFakeMatch(db: Kysely<Database>) {
+  await sql`
+    INSERT INTO matches (
+      checksum, demo_path, game_type, game_mode, game_mode_str, is_ranked, kill_count, death_count,
+      assist_count, shot_count, winner_name, winner_side, analyze_date, overtime_count, max_rounds, has_vac_live_ban
+    )
+    VALUES (${matchChecksum}, '/tmp/spike.dem', 0, 0, 'competitive', false, 0, 0, 0, 0, '', 0, now(), 0, 30, false)
+    ON CONFLICT (checksum) DO NOTHING
+  `.execute(db);
+}
+
+// Enough rows for COPY to exercise the CSV path and for aggregates to return int8/numeric values, small enough to keep
+// the suite fast. Throughput is not measured here.
+const positionsRowCount = 5_000;
+
+function buildPositionsCsv() {
+  const lines: string[] = [];
+  for (let index = 0; index < positionsRowCount; index++) {
+    const roundNumber = (index % 24) + 1;
+    lines.push(
+      `${matchChecksum},${roundNumber},${index},${index},7656119800000000${index % 10},player-${index % 10},t,${
+        index % 2048
+      }.5,${index % 1024}.25,64.125,180.5,0,2,100,16000,100,t,f,f,f,f,f,f,f,f`,
+    );
+  }
+
+  return lines.join('\n');
+}
+
+describe('PGlite dialect', () => {
+  it('runs all schema migrations (v1 to v14)', async () => {
+    const { db } = await getContext();
+
+    const tables = await db.introspection.getTables();
+    expect(tables.length).toBeGreaterThan(50);
+
+    const migration = await db
+      .selectFrom('migrations')
+      .select('schema_version as schemaVersion')
+      .orderBy('schema_version', 'desc')
+      .executeTakeFirstOrThrow();
+    // Also asserts the INT4 parser: schema_version must come back as a number, not a string.
+    expect(migration.schemaVersion).toBe(14);
+  });
+
+  it(`bulk-inserts ${positionsRowCount} player positions with COPY FROM '/dev/blob'`, async () => {
+    const { db, pglite } = await getContext();
+    await insertFakeMatch(db);
+
+    const columns =
+      'match_checksum,round_number,tick,frame,player_steam_id,player_name,is_alive,x,y,z,yaw,flash_duration_remaining,side,health,money,armor,has_helmet,has_bomb,has_defuse_kit,is_ducking,is_airborne,is_scoping,is_defusing,is_planting,is_grabbing_hostage';
+    const blob = new Blob([buildPositionsCsv()]);
+    await pglite.query(`COPY player_positions(${columns}) FROM '/dev/blob' WITH (FORMAT csv)`, [], { blob });
+
+    const { count } = await db
+      .selectFrom('player_positions')
+      .select(db.fn.countAll().as('count'))
+      .executeTakeFirstOrThrow();
+    // COUNT() returns an int8: asserts the INT8 parser converts it to a number.
+    expect(count).toBe(positionsRowCount);
+
+    const { averageX } = await db
+      .selectFrom('player_positions')
+      .select(sql`ROUND(AVG(x)::numeric, 2)`.as('averageX'))
+      .executeTakeFirstOrThrow();
+    // AVG()::numeric asserts the NUMERIC parser.
+    expect(typeof averageX).toBe('number');
+  });
+
+  it('executes PL/pgSQL triggers', async () => {
+    const { db } = await getContext();
+
+    const steamId = '76561198000000001';
+    await db
+      .insertInto('steam_accounts')
+      .values({
+        steam_id: steamId,
+        name: 'spike',
+        avatar: '',
+        is_community_banned: false,
+        has_private_profile: false,
+        vac_ban_count: 0,
+        game_ban_count: 0,
+        economy_ban: EconomyBan.None,
+      })
+      .execute();
+    await db.insertInto('ignored_steam_accounts').values({ steam_id: steamId }).execute();
+
+    const inserted = await db
+      .selectFrom('steam_accounts')
+      .select(['created_at', 'updated_at'])
+      .where('steam_id', '=', steamId)
+      .executeTakeFirstOrThrow();
+
+    await db.updateTable('steam_accounts').set({ name: 'spike-updated' }).where('steam_id', '=', steamId).execute();
+
+    const updated = await db
+      .selectFrom('steam_accounts')
+      .select('updated_at')
+      .where('steam_id', '=', steamId)
+      .executeTakeFirstOrThrow();
+    // The update_steam_account_updated_at trigger must have bumped updated_at.
+    expect(updated.updated_at.getTime()).toBeGreaterThan(inserted.updated_at.getTime());
+
+    // The steam_account_deleted trigger must cascade the delete to ignored_steam_accounts.
+    await db.deleteFrom('steam_accounts').where('steam_id', '=', steamId).execute();
+    const ignoredAccount = await db
+      .selectFrom('ignored_steam_accounts')
+      .select('steam_id')
+      .where('steam_id', '=', steamId)
+      .executeTakeFirst();
+    expect(ignoredAccount).toBeUndefined();
+  });
+
+  it('reads the player_ban_per_match view', async () => {
+    const { db } = await getContext();
+
+    const rows = await db.selectFrom('player_ban_per_match').selectAll().execute();
+    expect(Array.isArray(rows)).toBe(true);
+  });
+
+  it('exposes SQLSTATE error codes through getDatabaseErrorCode', async () => {
+    const { db } = await getContext();
+
+    const steamId = '76561198000000002';
+    const account = {
+      steam_id: steamId,
+      name: 'spike',
+      avatar: '',
+      is_community_banned: false,
+      has_private_profile: false,
+      vac_ban_count: 0,
+      game_ban_count: 0,
+      economy_ban: EconomyBan.None,
+    };
+    await db.insertInto('steam_accounts').values(account).execute();
+
+    let uniqueViolation: unknown;
+    try {
+      await db.insertInto('steam_accounts').values(account).execute();
+    } catch (error) {
+      uniqueViolation = error;
+    }
+    expect(getDatabaseErrorCode(uniqueViolation)).toBe(PostgresqlErrorCode.UniqueViolation);
+
+    let undefinedTable: unknown;
+    try {
+      await sql`SELECT * FROM table_that_does_not_exist`.execute(db);
+    } catch (error) {
+      undefinedTable = error;
+    }
+    expect(getDatabaseErrorCode(undefinedTable)).toBe(PostgresqlErrorCode.UndefinedTable);
+  });
+
+  it('serializes concurrent transactions on the single connection', async () => {
+    const { db } = await getContext();
+
+    // Kysely's PGlite driver alone would interleave these on the shared connection, the wrapper in
+    // pglite-dialect.ts must serialize them.
+    await Promise.all(
+      ['spike-tag-a', 'spike-tag-b'].map((name) => {
+        return db.transaction().execute(async (transaction) => {
+          await transaction.insertInto('tags').values({ name, color: '#ffffff' }).execute();
+          await transaction.selectFrom('tags').select('id').where('name', '=', name).executeTakeFirstOrThrow();
+        });
+      }),
+    );
+
+    const tags = await db
+      .selectFrom('tags')
+      .select('name')
+      .where('name', 'in', ['spike-tag-a', 'spike-tag-b'])
+      .execute();
+    expect(tags).toHaveLength(2);
+  });
+
+  it('supports the maintenance queries used by the app', async () => {
+    const { db } = await getContext();
+
+    // Used by the optimize database handler.
+    await sql`VACUUM FULL`.execute(db);
+
+    // Used to display the database size in the settings.
+    const result = await sql<{ size: string }>`
+      SELECT pg_size_pretty(pg_database_size(current_database())) AS size
+    `.execute(db);
+    expect(result.rows[0].size).toMatch(/\d+/);
+  });
+});

--- a/src/node/database/pglite/pglite-dialect.ts
+++ b/src/node/database/pglite/pglite-dialect.ts
@@ -1,0 +1,88 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { AbortableOperationOptions, DatabaseConnection, Driver, QueryCompiler, TransactionSettings } from 'kysely';
+import { PGliteDialect as KyselyPGliteDialect } from 'kysely';
+
+// Kysely's PGlite driver hands out a single shared connection without serializing access to it: concurrent
+// transactions would interleave on the same connection and corrupt each other's state. This wrapper serializes
+// connection acquisition, like Kysely's built-in SQLite driver does.
+class SerializedPGliteDriver implements Driver {
+  private readonly driver: Driver;
+  private lock: Promise<void> = Promise.resolve();
+  private releaseLock: (() => void) | undefined;
+
+  public constructor(driver: Driver) {
+    this.driver = driver;
+  }
+
+  public init(options?: AbortableOperationOptions): Promise<void> {
+    return this.driver.init(options);
+  }
+
+  public async acquireConnection(options?: AbortableOperationOptions): Promise<DatabaseConnection> {
+    const previousLock = this.lock;
+    let release!: () => void;
+    this.lock = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previousLock;
+    this.releaseLock = release;
+
+    return this.driver.acquireConnection(options);
+  }
+
+  public beginTransaction(connection: DatabaseConnection, settings: TransactionSettings): Promise<void> {
+    return this.driver.beginTransaction(connection, settings);
+  }
+
+  public commitTransaction(connection: DatabaseConnection): Promise<void> {
+    return this.driver.commitTransaction(connection);
+  }
+
+  public rollbackTransaction(connection: DatabaseConnection): Promise<void> {
+    return this.driver.rollbackTransaction(connection);
+  }
+
+  public savepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    return this.driver.savepoint!(connection, savepointName, compileQuery);
+  }
+
+  public rollbackToSavepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    return this.driver.rollbackToSavepoint!(connection, savepointName, compileQuery);
+  }
+
+  public releaseSavepoint(
+    connection: DatabaseConnection,
+    savepointName: string,
+    compileQuery: QueryCompiler['compileQuery'],
+  ): Promise<void> {
+    return this.driver.releaseSavepoint!(connection, savepointName, compileQuery);
+  }
+
+  public async releaseConnection(connection: DatabaseConnection, options?: AbortableOperationOptions): Promise<void> {
+    await this.driver.releaseConnection(connection, options);
+    this.releaseLock?.();
+    this.releaseLock = undefined;
+  }
+
+  public destroy(options?: AbortableOperationOptions): Promise<void> {
+    return this.driver.destroy(options);
+  }
+}
+
+export class PGliteDialect extends KyselyPGliteDialect {
+  public constructor(pglite: PGlite) {
+    super({ pglite });
+  }
+
+  public override createDriver(): Driver {
+    return new SerializedPGliteDriver(super.createDriver());
+  }
+}

--- a/src/node/database/pglite/pglite-instance.ts
+++ b/src/node/database/pglite/pglite-instance.ts
@@ -1,0 +1,84 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import { PGlite, types } from '@electric-sql/pglite';
+import { getAppFolderPath } from 'csdm/node/filesystem/get-app-folder-path';
+import { EmbeddedDatabaseLocked } from './errors/embedded-database-locked';
+import { isProcessAlive } from 'csdm/node/os/is-process-alive';
+
+let instance: PGlite | undefined;
+
+function getPgliteDataFolderPath() {
+  return path.join(getAppFolderPath(), 'database');
+}
+
+// PGlite doesn't lock its data folder: opening it from several processes at the same time (the app and the CLI
+// typically) could corrupt it. A lock file containing the owner PID guards against it.
+// Locks from dead processes (crash, kill…) are simply taken over, so the lock file is never explicitly released.
+async function acquireDataFolderLock(dataFolderPath: string) {
+  const lockFilePath = path.join(dataFolderPath, 'csdm.lock');
+  try {
+    const pid = Number(await fs.readFile(lockFilePath, 'utf8'));
+    if (pid !== process.pid && isProcessAlive(pid)) {
+      throw new EmbeddedDatabaseLocked(pid);
+    }
+  } catch (error) {
+    if (error instanceof EmbeddedDatabaseLocked) {
+      throw error;
+    }
+    // The lock file doesn't exist or is unreadable, take the lock.
+  }
+
+  await fs.writeFile(lockFilePath, String(process.pid));
+}
+
+export async function createPgliteInstance() {
+  // A previous instance may still be open when re-connecting after an error (e.g. a failed schema migration), it has
+  // to be closed first because only one connection to the data folder is allowed.
+  if (instance !== undefined && !instance.closed) {
+    await instance.close();
+  }
+
+  const dataFolderPath = getPgliteDataFolderPath();
+  await fs.ensureDir(dataFolderPath);
+  await acquireDataFolderLock(dataFolderPath);
+
+  // PGlite loads its WASM/data files itself, using fetch() in browser-like environments and fs in Node.
+  // Its environment detection is fragile (e.g. it falls back to the browser code paths depending on process.type),
+  // loading the files explicitly from the package folder works in every environment (daemon process, CLI).
+  const distFolderPath = path.dirname(require.resolve('@electric-sql/pglite'));
+  const [pgliteWasm, initdbWasm, fsBundle] = await Promise.all([
+    fs.readFile(path.join(distFolderPath, 'pglite.wasm')),
+    fs.readFile(path.join(distFolderPath, 'initdb.wasm')),
+    fs.readFile(path.join(distFolderPath, 'pglite.data')),
+  ]);
+
+  instance = await PGlite.create(dataFolderPath, {
+    pgliteWasmModule: await WebAssembly.compile(pgliteWasm),
+    initdbWasmModule: await WebAssembly.compile(initdbWasm),
+    fsBundle: new Blob([fsBundle]),
+    parsers: {
+      [types.INT8]: (value: string) => {
+        const valueAsNumber = Number(value);
+        if (Number.isSafeInteger(valueAsNumber)) {
+          return valueAsNumber;
+        }
+
+        return value;
+      },
+      [types.NUMERIC]: Number,
+      [types.INT4]: Number,
+      [types.INT2]: Number,
+    },
+  });
+
+  return instance;
+}
+
+// The raw PGlite instance is required for queries not supported by Kysely, like COPY with a blob.
+export function getPgliteInstance(): PGlite {
+  if (instance === undefined || instance.closed) {
+    throw new Error('The PGlite instance is not initialized');
+  }
+
+  return instance;
+}

--- a/src/node/database/steam-accounts/add-ignored-steam-account.ts
+++ b/src/node/database/steam-accounts/add-ignored-steam-account.ts
@@ -1,5 +1,5 @@
-import { DatabaseError } from 'pg';
 import { db } from '../database';
+import { getDatabaseErrorCode } from 'csdm/node/database/get-database-error-code';
 import { getPlayerSteamIdFromSteamUrl } from 'csdm/node/steam-web-api/get-player-steam-id-from-steam-url';
 import { SteamAccountAlreadyIgnored } from 'csdm/node/database/steam-accounts/errors/steam-account-already-ignored';
 import { fetchIgnoredSteamAccounts } from 'csdm/node/database/steam-accounts/fetch-ignored-steam-accounts';
@@ -27,11 +27,8 @@ export async function addIgnoredSteamAccount(steamIdentifier: string) {
     };
     await db.insertInto('ignored_steam_accounts').values(row).execute();
   } catch (error) {
-    if (error instanceof DatabaseError) {
-      switch (error.code) {
-        case PostgresqlErrorCode.UniqueViolation:
-          throw new SteamAccountAlreadyIgnored();
-      }
+    if (getDatabaseErrorCode(error) === PostgresqlErrorCode.UniqueViolation) {
+      throw new SteamAccountAlreadyIgnored();
     }
     throw error;
   }

--- a/src/node/database/tags/insert-tag.ts
+++ b/src/node/database/tags/insert-tag.ts
@@ -1,5 +1,5 @@
-import { DatabaseError } from 'pg';
 import { db } from 'csdm/node/database/database';
+import { getDatabaseErrorCode } from 'csdm/node/database/get-database-error-code';
 import { PostgresqlErrorCode } from '../postgresql-error-code';
 import { assertValidTag } from './assert-valid-tag';
 import { TagNameAlreadyTaken } from './errors/tag-name-already-taken';
@@ -15,11 +15,8 @@ export async function insertTag(tag: InsertableTag) {
 
     return newTag;
   } catch (error) {
-    if (error instanceof DatabaseError) {
-      switch (error.code) {
-        case PostgresqlErrorCode.UniqueViolation:
-          throw new TagNameAlreadyTaken();
-      }
+    if (getDatabaseErrorCode(error) === PostgresqlErrorCode.UniqueViolation) {
+      throw new TagNameAlreadyTaken();
     }
     throw error;
   }

--- a/src/node/database/tags/update-tag.ts
+++ b/src/node/database/tags/update-tag.ts
@@ -1,5 +1,5 @@
-import { DatabaseError } from 'pg';
 import { db } from 'csdm/node/database/database';
+import { getDatabaseErrorCode } from 'csdm/node/database/get-database-error-code';
 import { PostgresqlErrorCode } from '../postgresql-error-code';
 import { assertValidTag } from './assert-valid-tag';
 import { TagNameAlreadyTaken } from './errors/tag-name-already-taken';
@@ -11,11 +11,8 @@ export async function updateTag(tag: Tag) {
   try {
     await db.updateTable('tags').set(tag).where('id', '=', tag.id).execute();
   } catch (error) {
-    if (error instanceof DatabaseError) {
-      switch (error.code) {
-        case PostgresqlErrorCode.UniqueViolation:
-          throw new TagNameAlreadyTaken();
-      }
+    if (getDatabaseErrorCode(error) === PostgresqlErrorCode.UniqueViolation) {
+      throw new TagNameAlreadyTaken();
     }
     throw error;
   }

--- a/src/node/os/is-process-alive.ts
+++ b/src/node/os/is-process-alive.ts
@@ -1,4 +1,8 @@
 export function isProcessAlive(pid: number) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+
   try {
     process.kill(pid, 0);
     return true;

--- a/src/node/settings/default-settings.ts
+++ b/src/node/settings/default-settings.ts
@@ -8,11 +8,13 @@ import { VideoContainer } from 'csdm/common/types/video-container';
 import { RecordingSystem } from 'csdm/common/types/recording-system';
 import { RecordingOutput } from 'csdm/common/types/recording-output';
 import { DisplayMode } from 'csdm/common/types/display-mode';
+import { DatabaseMode } from 'csdm/common/types/database-mode';
 
 export const defaultSettings: Settings = {
   schemaVersion: CURRENT_SCHEMA_VERSION,
   autoDownloadUpdates: true,
   database: {
+    mode: DatabaseMode.Embedded,
     hostname: '127.0.0.1',
     port: 5432,
     username: 'postgres',

--- a/src/node/settings/get-all-migrations.ts
+++ b/src/node/settings/get-all-migrations.ts
@@ -18,6 +18,7 @@ export async function getAllMigrations(): Promise<Migration[]> {
     import('./migrations/v11'),
     import('./migrations/v12'),
     import('./migrations/v13'),
+    import('./migrations/v14'),
   ]);
   const migrations: Migration[] = modules.map((module) => module.default);
 

--- a/src/node/settings/migrations/v14.ts
+++ b/src/node/settings/migrations/v14.ts
@@ -1,0 +1,18 @@
+import type { Settings } from '../settings';
+import type { Migration } from '../migration';
+import { DatabaseMode } from 'csdm/common/types/database-mode';
+
+// Existing installations were using a PostgreSQL server, only fresh installations default to the embedded database.
+const v14: Migration = {
+  schemaVersion: 14,
+  run: (settings: Settings) => {
+    settings.database = {
+      ...settings.database,
+      mode: DatabaseMode.PostgreSql,
+    };
+
+    return Promise.resolve(settings);
+  },
+};
+
+export default v14;

--- a/src/node/settings/schema-version.ts
+++ b/src/node/settings/schema-version.ts
@@ -2,4 +2,4 @@
 // It's used to migrate settings schema at app startup.
 // If you need to alter the settings schema or change current settings values, this variable has to be incremented
 // and the corresponding migration must be added to the getAllMigrations function!
-export const CURRENT_SCHEMA_VERSION = 13;
+export const CURRENT_SCHEMA_VERSION = 14;

--- a/src/node/settings/settings.ts
+++ b/src/node/settings/settings.ts
@@ -12,6 +12,7 @@ import type { RecordingSystem } from 'csdm/common/types/recording-system';
 import type { RecordingOutput } from 'csdm/common/types/recording-output';
 import type { DisplayMode } from 'csdm/common/types/display-mode';
 import type { ArchiveFormat } from 'csdm/common/types/archive-format';
+import type { DatabaseMode } from 'csdm/common/types/database-mode';
 
 export type Folder = {
   path: string;
@@ -19,6 +20,9 @@ export type Folder = {
 };
 
 export type DatabaseSettings = {
+  // The embedded mode uses PGlite, a bundled Postgres that doesn't require a PostgreSQL installation.
+  // The connection fields below are used only in "postgresql" mode.
+  readonly mode: DatabaseMode;
   readonly hostname: string;
   readonly port: number;
   readonly username: string;

--- a/src/ui/bootstrap/connect-database/connect-database.tsx
+++ b/src/ui/bootstrap/connect-database/connect-database.tsx
@@ -1,6 +1,10 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Plural, Trans } from '@lingui/react/macro';
+import { Plural, Trans, useLingui } from '@lingui/react/macro';
 import { useDispatch } from 'csdm/ui/store/use-dispatch';
+import type { SelectOption } from 'csdm/ui/components/inputs/select';
+import { Select } from 'csdm/ui/components/inputs/select';
+import { InputLabel } from 'csdm/ui/components/inputs/input-label';
+import { DatabaseMode } from 'csdm/common/types/database-mode';
 import { PortInput } from 'csdm/ui/components/inputs/port-input';
 import { DatabaseNameInput } from 'csdm/ui/components/inputs/database-name-input';
 import { UsernameInput } from 'csdm/ui/components/inputs/username-input';
@@ -52,6 +56,15 @@ function getHintFromError({ code, message }: ConnectDatabaseError) {
   switch (code) {
     case ErrorCode.DatabaseSchemaVersionMismatch:
       return <DatabaseSchemaVersionMismatch />;
+    case ErrorCode.EmbeddedDatabaseLocked:
+      return (
+        <p>
+          <Trans>
+            It usually means that another instance of CS Demo Manager or its command line interface is already using the
+            database. Close it and try again.
+          </Trans>
+        </p>
+      );
   }
 
   if (message.includes('ECONNREFUSED')) {
@@ -68,6 +81,44 @@ function getHintFromError({ code, message }: ConnectDatabaseError) {
     <p>
       <Trans>Make sure PostgreSQL is running and your settings are correct.</Trans>
     </p>
+  );
+}
+
+function DatabaseModeSelect({
+  mode,
+  onChange,
+  isDisabled,
+}: {
+  mode: DatabaseMode;
+  onChange: (mode: DatabaseMode) => void;
+  isDisabled: boolean;
+}) {
+  const { t } = useLingui();
+
+  const options: SelectOption<DatabaseMode>[] = [
+    {
+      value: DatabaseMode.Embedded,
+      label: t({
+        context: 'Select option database mode',
+        message: 'Embedded (default)',
+      }),
+    },
+    {
+      value: DatabaseMode.PostgreSql,
+      label: t({
+        context: 'Select option database mode',
+        message: 'PostgreSQL server',
+      }),
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-y-8">
+      <InputLabel>
+        <Trans context="Input label">Database</Trans>
+      </InputLabel>
+      <Select options={options} value={mode} onChange={onChange} isDisabled={isDisabled} />
+    </div>
   );
 }
 
@@ -179,66 +230,89 @@ export function ConnectDatabase() {
         <div className="m-auto flex flex-col">
           <div className="m-auto flex w-[400px] flex-col">
             <div>
-              <p>
-                <Trans>CS Demo Manager requires a PostgreSQL database.</Trans>
-              </p>
+              {databaseSettings.mode === DatabaseMode.Embedded ? (
+                <p>
+                  <Trans>
+                    CS Demo Manager uses an embedded database by default, no configuration is required. You can also use
+                    a PostgreSQL server.
+                  </Trans>
+                </p>
+              ) : (
+                <p>
+                  <Trans>CS Demo Manager requires a PostgreSQL database.</Trans>
+                </p>
+              )}
               <HelpLink />
             </div>
             <div className="mt-12 flex flex-col gap-12">
-              <div className="flex gap-x-8">
-                <div className="w-full">
-                  <HostnameInput
-                    hostname={databaseSettings.hostname}
+              <DatabaseModeSelect
+                mode={databaseSettings.mode}
+                onChange={(mode: DatabaseMode) => {
+                  setDatabaseSettings({
+                    ...databaseSettings,
+                    mode,
+                  });
+                }}
+                isDisabled={isConnecting}
+              />
+              {databaseSettings.mode === DatabaseMode.PostgreSql && (
+                <>
+                  <div className="flex gap-x-8">
+                    <div className="w-full">
+                      <HostnameInput
+                        hostname={databaseSettings.hostname}
+                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                          setDatabaseSettings({
+                            ...databaseSettings,
+                            hostname: event.target.value,
+                          });
+                        }}
+                        isDisabled={isConnecting}
+                      />
+                    </div>
+                    <PortInput
+                      port={databaseSettings.port}
+                      onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                        setDatabaseSettings({
+                          ...databaseSettings,
+                          port: +event.target.value,
+                        });
+                      }}
+                      isDisabled={isConnecting}
+                    />
+                  </div>
+                  <DatabaseNameInput
+                    databaseName={databaseSettings.database}
                     onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                       setDatabaseSettings({
                         ...databaseSettings,
-                        hostname: event.target.value,
+                        database: event.target.value,
                       });
                     }}
                     isDisabled={isConnecting}
                   />
-                </div>
-                <PortInput
-                  port={databaseSettings.port}
-                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                    setDatabaseSettings({
-                      ...databaseSettings,
-                      port: +event.target.value,
-                    });
-                  }}
-                  isDisabled={isConnecting}
-                />
-              </div>
-              <DatabaseNameInput
-                databaseName={databaseSettings.database}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                  setDatabaseSettings({
-                    ...databaseSettings,
-                    database: event.target.value,
-                  });
-                }}
-                isDisabled={isConnecting}
-              />
-              <UsernameInput
-                username={databaseSettings.username}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                  setDatabaseSettings({
-                    ...databaseSettings,
-                    username: event.target.value,
-                  });
-                }}
-                isDisabled={isConnecting}
-              />
-              <PasswordInput
-                password={databaseSettings.password}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                  setDatabaseSettings({
-                    ...databaseSettings,
-                    password: event.target.value,
-                  });
-                }}
-                isDisabled={isConnecting}
-              />
+                  <UsernameInput
+                    username={databaseSettings.username}
+                    onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                      setDatabaseSettings({
+                        ...databaseSettings,
+                        username: event.target.value,
+                      });
+                    }}
+                    isDisabled={isConnecting}
+                  />
+                  <PasswordInput
+                    password={databaseSettings.password}
+                    onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                      setDatabaseSettings({
+                        ...databaseSettings,
+                        password: event.target.value,
+                      });
+                    }}
+                    isDisabled={isConnecting}
+                  />
+                </>
+              )}
               <div className="flex items-center justify-between">
                 <ConnectDatabaseButton isLoading={isConnecting} onClick={connectDatabase} />
                 {secondsBeforeNextTry > 0 && (

--- a/src/ui/settings/database/database.tsx
+++ b/src/ui/settings/database/database.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Trans } from '@lingui/react/macro';
 import { PortInput } from '../../components/inputs/port-input';
 import { DatabaseNameInput } from '../../components/inputs/database-name-input';
 import { UsernameInput } from '../../components/inputs/username-input';
@@ -6,9 +7,26 @@ import { PasswordInput } from '../../components/inputs/password-input';
 import { DisconnectDatabaseButton } from './disconnect-database-button';
 import { useDatabaseSettings } from './use-database-settings';
 import { HostnameInput } from 'csdm/ui/components/inputs/hostname-input';
+import { DatabaseMode } from 'csdm/common/types/database-mode';
 
 export function Database() {
-  const { hostname, port, username, password, database } = useDatabaseSettings();
+  const { mode, hostname, port, username, password, database } = useDatabaseSettings();
+
+  if (mode === DatabaseMode.Embedded) {
+    return (
+      <div className="flex flex-col gap-y-8">
+        <p>
+          <Trans>The database is embedded with CS Demo Manager, no configuration is required.</Trans>
+        </p>
+        <p>
+          <Trans>To use a PostgreSQL server instead, disconnect and select it from the connection screen.</Trans>
+        </p>
+        <div className="mt-12">
+          <DisconnectDatabaseButton />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex max-w-[264px] flex-col gap-y-8">

--- a/src/ui/translations/en/messages.po
+++ b/src/ui/translations/en/messages.po
@@ -338,6 +338,10 @@ msgid "You can either update CS Demo Manager to the latest version or reset the 
 msgstr "You can either update CS Demo Manager to the latest version or reset the database to start from scratch."
 
 #: src/ui/bootstrap/connect-database/connect-database.tsx
+msgid "It usually means that another instance of CS Demo Manager or its command line interface is already using the database. Close it and try again."
+msgstr "It usually means that another instance of CS Demo Manager or its command line interface is already using the database. Close it and try again."
+
+#: src/ui/bootstrap/connect-database/connect-database.tsx
 msgid "This error usually means that the database is not running or that the connection settings are incorrect."
 msgstr "This error usually means that the database is not running or that the connection settings are incorrect."
 
@@ -346,8 +350,27 @@ msgid "Make sure PostgreSQL is running and your settings are correct."
 msgstr "Make sure PostgreSQL is running and your settings are correct."
 
 #: src/ui/bootstrap/connect-database/connect-database.tsx
+msgctxt "Select option database mode"
+msgid "Embedded (default)"
+msgstr "Embedded (default)"
+
+#: src/ui/bootstrap/connect-database/connect-database.tsx
+msgctxt "Select option database mode"
+msgid "PostgreSQL server"
+msgstr "PostgreSQL server"
+
+#: src/ui/bootstrap/connect-database/connect-database.tsx
+msgctxt "Input label"
+msgid "Database"
+msgstr "Database"
+
+#: src/ui/bootstrap/connect-database/connect-database.tsx
 msgid "The connection to the database failed with the following error:"
 msgstr "The connection to the database failed with the following error:"
+
+#: src/ui/bootstrap/connect-database/connect-database.tsx
+msgid "CS Demo Manager uses an embedded database by default, no configuration is required. You can also use a PostgreSQL server."
+msgstr "CS Demo Manager uses an embedded database by default, no configuration is required. You can also use a PostgreSQL server."
 
 #: src/ui/bootstrap/connect-database/connect-database.tsx
 msgid "CS Demo Manager requires a PostgreSQL database."
@@ -7195,6 +7218,14 @@ msgstr "Yaw"
 #: src/ui/settings/database/database-size.tsx
 msgid "Database size: <0>{size}</0>."
 msgstr "Database size: <0>{size}</0>."
+
+#: src/ui/settings/database/database.tsx
+msgid "The database is embedded with CS Demo Manager, no configuration is required."
+msgstr "The database is embedded with CS Demo Manager, no configuration is required."
+
+#: src/ui/settings/database/database.tsx
+msgid "To use a PostgreSQL server instead, disconnect and select it from the connection screen."
+msgstr "To use a PostgreSQL server instead, disconnect and select it from the connection screen."
 
 #: src/ui/settings/database/disconnect-database-button.tsx
 msgctxt "Dialog title"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `@electric-sql/pglite` as an embedded PostgreSQL backend. Fresh installations now use the bundled database instead of requiring a PostgreSQL server; existing installations remain on PostgreSQL through the settings migration, and users can choose either mode from the connection screen.

**New Features**

- Stores embedded database files in the app data directory and prevents simultaneous access from the app and CLI with a clear lock error.
- Supports schema migrations, bulk CSV imports, PostgreSQL error handling, maintenance queries, and serialized transactions in embedded mode.
- Packages PGlite’s runtime assets for development, CLI, and production builds and adds integration coverage for the new backend.

<sup>Written for commit 10b4eedac47425636da3f4abf5cc540bb6b1f5ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/akiver/cs-demo-manager/pull/1467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

